### PR TITLE
fix arm runners selection by checking if repo is private

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -229,6 +229,7 @@ jobs:
               target = targets[0];
             });
 
+            const privateRepo = GitHub.context.payload.repository?.private ?? false;
             await core.group(`Set includes`, async () => {
               let includes = [];
               const platforms = def.target[target].platforms || [];
@@ -244,7 +245,7 @@ jobs:
                   includes.push({
                     index: index,
                     platform: platform,
-                    runner: GitHub.isGHES && platform.startsWith('linux/arm') ? 'ubuntu-24.04-arm' : 'ubuntu-24.04'
+                    runner: (!privateRepo && platform.startsWith('linux/arm')) ? 'ubuntu-24.04-arm' : 'ubuntu-24.04' // FIXME: ubuntu-24.04-arm runner not yet available for private repos
                   });
                 });
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,7 @@ jobs:
             
             const inpBuildPlatforms = Util.getInputList('build-platforms');
             
+            const privateRepo = GitHub.context.payload.repository?.private ?? false;
             await core.group(`Set includes`, async () => {
               let includes = [];
               if (inpBuildPlatforms.length > inpMatrixSizeLimit) {
@@ -198,7 +199,7 @@ jobs:
                   includes.push({
                     index: index,
                     platform: platform,
-                    runner: GitHub.isGHES && platform.startsWith('linux/arm') ? 'ubuntu-24.04-arm' : 'ubuntu-24.04'
+                    runner: (!privateRepo && platform.startsWith('linux/arm')) ? 'ubuntu-24.04-arm' : 'ubuntu-24.04' // FIXME: ubuntu-24.04-arm runner not yet available for private repos
                   });
                 });
               }


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/19764305328/job/56633335583

We should check repos are public to enable arm runners and not GHES. Arm runners are in public Beta which means they are enabled only for public repos.