### PR TITLE
runner input

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -278,6 +278,22 @@ jobs:
     with:
       builder-outputs: ${{ toJSON(needs.build-local-single.outputs) }}
 
+  build-set-runner:
+    uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      runner: amd64
+      output: image
+      push: false
+      meta-images: ghcr.io/docker/github-builder-test
+      meta-tags: |
+        type=raw,value=build-${{ github.run_id }}
+      build-file: test/hello.Dockerfile
+      build-platforms: linux/amd64,linux/arm64
+
   bake-aws-single:
     uses: ./.github/workflows/bake.yml
     permissions:
@@ -441,3 +457,20 @@ jobs:
       - bake-local-single
     with:
       builder-outputs: ${{ toJSON(needs.bake-local-single.outputs) }}
+
+  bake-set-runner:
+    uses: ./.github/workflows/bake.yml
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    with:
+      runner: amd64
+      context: test
+      target: hello-cross
+      output: image
+      push: false
+      meta-images: |
+        public.ecr.aws/q3b5f1u4/test-docker-action
+      meta-tags: |
+        type=raw,value=bake-ghbuilder-${{ github.run_id }}

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -3,6 +3,11 @@ name: bake
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        description: "Linux machine to run build on. Can be one of auto, amd64, arm64 (defaults to auto which selects best-matching runner based on target platform)"
+        required: false
+        default: 'auto'
       context:
         type: string
         description: "Context to build from (defaults to repository root)"
@@ -175,6 +180,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           INPUT_MATRIX-SIZE-LIMIT: ${{ env.MATRIX_SIZE_LIMIT }}
+          INPUT_RUNNER: ${{ inputs.runner }}
           INPUT_CONTEXT: ${{ inputs.context }}
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_BAKE-ALLOW: ${{ inputs.bake-allow }}
@@ -192,6 +198,7 @@ jobs:
 
             const inpMatrixSizeLimit = parseInt(core.getInput('matrix-size-limit'), 10);
             
+            const inpRunner = core.getInput('runner');
             const inpContext = core.getInput('context');
             const inpTarget = core.getInput('target');
             const inpBakeAllow = core.getInput('bake-allow');
@@ -200,6 +207,15 @@ jobs:
             const inpBakeSbom = core.getInput('bake-sbom');
             const inpBakeSet = Util.getInputList('bake-set', {ignoreComma: true, quote: false});
             const inpGitHubToken = core.getInput('github-token');
+            
+            let runner = inpRunner;
+            if (inpRunner === 'amd64') {
+              runner = 'ubuntu-24.04';
+            } else if (inpRunner === 'arm64') {
+              runner = 'ubuntu-24.04-arm';
+            } else if (inpRunner !== 'auto') {
+              throw new Error(`Invalid runner input: ${inpRunner}`);
+            }
 
             const bakeSource = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}.git#${process.env.GITHUB_REF}:${inpContext}`;
             await core.group(`Set bake source`, async () => {
@@ -238,14 +254,14 @@ jobs:
               } else if (platforms.length === 0) {
                 includes.push({
                   index: 0,
-                  runner: 'ubuntu-24.04'
+                  runner: runner === 'auto' ? 'ubuntu-24.04' : runner
                 });
               } else {
                 platforms.forEach((platform, index) => {
                   includes.push({
                     index: index,
                     platform: platform,
-                    runner: (!privateRepo && platform.startsWith('linux/arm')) ? 'ubuntu-24.04-arm' : 'ubuntu-24.04' // FIXME: ubuntu-24.04-arm runner not yet available for private repos
+                    runner: runner === 'auto' ? ((!privateRepo && platform.startsWith('linux/arm')) ? 'ubuntu-24.04-arm' : 'ubuntu-24.04') : runner
                   });
                 });
               }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: build
 on:
   workflow_call:
     inputs:
+      runner:
+        type: string
+        description: "Linux machine to run build on. Can be one of auto, amd64, arm64 (defaults to auto which selects best-matching runner based on target platform)"
+        required: false
+        default: 'auto'
       context:
         type: string
         description: "Context to build from (defaults to repository root)"
@@ -174,6 +179,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           INPUT_MATRIX-SIZE-LIMIT: ${{ env.MATRIX_SIZE_LIMIT }}
+          INPUT_RUNNER: ${{ inputs.runner }}
           INPUT_BUILD-PLATFORMS: ${{ inputs.build-platforms }}
         with:
           script: |
@@ -182,7 +188,17 @@ jobs:
             
             const inpMatrixSizeLimit = parseInt(core.getInput('matrix-size-limit'), 10);
             
+            const inpRunner = core.getInput('runner');
             const inpBuildPlatforms = Util.getInputList('build-platforms');
+            
+            let runner = inpRunner;
+            if (inpRunner === 'amd64') {
+              runner = 'ubuntu-24.04';
+            } else if (inpRunner === 'arm64') {
+              runner = 'ubuntu-24.04-arm';
+            } else if (inpRunner !== 'auto') {
+              throw new Error(`Invalid runner input: ${inpRunner}`);
+            }
             
             const privateRepo = GitHub.context.payload.repository?.private ?? false;
             await core.group(`Set includes`, async () => {
@@ -192,14 +208,14 @@ jobs:
               } else if (inpBuildPlatforms.length === 0) {
                 includes.push({
                   index: 0,
-                  runner: 'ubuntu-24.04'
+                  runner: runner === 'auto' ? 'ubuntu-24.04' : runner
                 });
               } else {
                 inpBuildPlatforms.forEach((platform, index) => {
                   includes.push({
                     index: index,
                     platform: platform,
-                    runner: (!privateRepo && platform.startsWith('linux/arm')) ? 'ubuntu-24.04-arm' : 'ubuntu-24.04' // FIXME: ubuntu-24.04-arm runner not yet available for private repos
+                    runner: runner === 'auto' ? ((!privateRepo && platform.startsWith('linux/arm')) ? 'ubuntu-24.04-arm' : 'ubuntu-24.04') : runner
                   });
                 });
               }


### PR DESCRIPTION
Adds `runner` input for both build and bake reusable workflows.

Value can be one of `auto`, `amd64`, `arm64`:
* `auto`: selects best-matching runner based on target platform ( `ubuntu-24.04` or  `ubuntu-24.04-arm`)
* `amd64`: use `ubuntu-24.04` github hosted runner
* `arm64`: use `ubuntu-24.04-arm` github hosted runner

Main use case is to be able to enforce specific runner arch if user knows emulation is not needed when doing multi-platform builds. Specially useful since arm runners are still in Beta: https://github.com/actions/partner-runner-images/?tab=readme-ov-file#available-images