### PR TITLE
remove permissions block in reusable workflows

### DIFF
--- a/.github/workflows/.test.yml
+++ b/.github/workflows/.test.yml
@@ -4,9 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
   push:
@@ -22,7 +19,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       output: image
@@ -57,7 +53,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       output: image
@@ -94,8 +89,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
+      packages: write
     with:
       output: image
       push: ${{ github.event_name != 'pull_request' }}
@@ -128,7 +123,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       output: image
@@ -162,7 +156,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       output: image
@@ -197,8 +190,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
+      packages: write
     with:
       output: image
       push: ${{ github.event_name != 'pull_request' }}
@@ -239,7 +232,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       output: local
@@ -261,7 +253,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       output: local
@@ -282,7 +273,6 @@ jobs:
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       runner: amd64
@@ -298,7 +288,6 @@ jobs:
     uses: ./.github/workflows/bake.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       context: test
@@ -335,7 +324,6 @@ jobs:
     uses: ./.github/workflows/bake.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       context: test
@@ -372,8 +360,8 @@ jobs:
     uses: ./.github/workflows/bake.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
+      packages: write
     with:
       context: test
       target: hello-cross
@@ -416,7 +404,6 @@ jobs:
     uses: ./.github/workflows/bake.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       context: test
@@ -439,7 +426,6 @@ jobs:
     uses: ./.github/workflows/bake.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       context: test
@@ -462,7 +448,6 @@ jobs:
     uses: ./.github/workflows/bake.yml
     permissions:
       contents: read
-      packages: write
       id-token: write
     with:
       runner: amd64

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -149,8 +149,6 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
     outputs:
       includes: ${{ steps.set.outputs.includes }}
     steps:
@@ -273,10 +271,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs:
       - prepare
-    permissions:
-      contents: read
-      id-token: write # for signing attestation manifests and/or registry authentication with GitHub OIDC Token
-      packages: write # for pushing manifests to GHCR if needed
     strategy:
       fail-fast: false
       matrix:
@@ -657,10 +651,6 @@ jobs:
 
   finalize:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      id-token: write # for registry authentication with OIDC if needed
-      packages: write # for pushing to GHCR when merging manifests if needed
     outputs:
       cosign-version: ${{ env.COSIGN_VERSION }}
       cosign-verify-commands: ${{ steps.set.outputs.cosign-verify-commands }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,8 +160,6 @@ env:
 jobs:
   prepare:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
     outputs:
       includes: ${{ steps.set.outputs.includes }}
     steps:
@@ -227,10 +225,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs:
       - prepare
-    permissions:
-      contents: read
-      id-token: write # for signing attestation manifests and/or registry authentication with GitHub OIDC Token
-      packages: write # for pushing manifests to GHCR if needed
     strategy:
       fail-fast: false
       matrix:
@@ -551,10 +545,6 @@ jobs:
 
   finalize:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      id-token: write # for registry authentication with OIDC if needed
-      packages: write # for pushing to GHCR when merging manifests if needed
     outputs:
       cosign-version: ${{ env.COSIGN_VERSION }}
       cosign-verify-commands: ${{ steps.set.outputs.cosign-verify-commands }}

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ on:
   build:
     uses: docker/github-builder-experimental/.github/workflows/build.yml@main
     permissions:
-      contents: read
-      id-token: write # for signing attestation manifests and registry authentication if needed with GitHub OIDC Token
-      packages: write # for pushing manifests to GHCR if needed (caller must provide the same permissions used in the reusable workflow)
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestation manifests with GitHub OIDC Token
     with:
       output: image
       push: ${{ github.event_name != 'pull_request' }}
@@ -91,9 +90,8 @@ on:
   bake:
     uses: docker/github-builder-experimental/.github/workflows/bake.yml@main
     permissions:
-      contents: read
-      id-token: write # for signing attestation manifests and registry authentication if needed with GitHub OIDC Token
-      packages: write # for pushing manifests to GHCR if needed (caller must provide the same permissions used in the reusable workflow)
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestation manifests with GitHub OIDC Token
     with:
       output: image
       push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
relates to #24 

We should not define permissions in the reusable workflow but let caller decides.