### PR TITLE
fix cache signing config

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -390,7 +390,7 @@ jobs:
                     timestampThreshold = 1
                     tlogThreshold = ${{ needs.prepare.outputs.privateRepo == 'true' && '0' || '1' }}
                     subjectAlternativeName = "https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml*"
-                    githubWorkflowRepository = "docker/github-builder-experimental"
+                    githubWorkflowRepository = "${{ github.repository }}"
                     issuer = "https://token.actions.githubusercontent.com"
                     runnerEnvironment = "github-hosted"
                     sourceRepositoryURI = "${{ github.server_url }}/${{ github.repository }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,7 +350,7 @@ jobs:
                     timestampThreshold = 1
                     tlogThreshold = ${{ needs.prepare.outputs.privateRepo == 'true' && '0' || '1' }}
                     subjectAlternativeName = "https://github.com/docker/github-builder-experimental/.github/workflows/build.yml*"
-                    githubWorkflowRepository = "docker/github-builder-experimental"
+                    githubWorkflowRepository = "${{ github.repository }}"
                     issuer = "https://token.actions.githubusercontent.com"
                     runnerEnvironment = "github-hosted"
                     sourceRepositoryURI = "${{ github.server_url }}/${{ github.repository }}"


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/20885866349/job/60008960190#step:10:541

```
#29 exporting to GitHub Actions Cache
#29 preparing build cache for export
#29 writing layer sha256:20ae2f90a4a205b860bfa6ff116489885225cbef9e2cbc8f93fd957f39321643
#29 writing layer sha256:20ae2f90a4a205b860bfa6ff116489885225cbef9e2cbc8f93fd957f39321643 0.5s done
#29 writing layer sha256:a785c78e2dcb466bd6296d5eb205c9d864a9589d8d645b7c950879ae5479e41f
#29 writing layer sha256:a785c78e2dcb466bd6296d5eb205c9d864a9589d8d645b7c950879ae5479e41f 2.5s done
#29 signing cache index sha256:f10fb1cd86490268d39dc7a75578719f31183203c71f00afbfaec176374bf36d
#29 preparing build cache for export 7.5s done
#29 signing cache index sha256:f10fb1cd86490268d39dc7a75578719f31183203c71f00afbfaec176374bf36d 1.7s done
#29 ERROR: signature verification failed: certificate field "githubWorkflowRepository" does not match policy ("docker/buildx" != "docker/github-builder-experimental")
```