### PR TITLE
cache: remove sourceRepositoryRef policy

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -394,7 +394,6 @@ jobs:
                     issuer = "https://token.actions.githubusercontent.com"
                     runnerEnvironment = "github-hosted"
                     sourceRepositoryURI = "${{ github.server_url }}/${{ github.repository }}"
-                    sourceRepositoryRef = "${{ github.event_name != 'pull_request' && github.ref || '' }}"
       -
         name: Install Cosign
         if: ${{ needs.prepare.outputs.sign == 'true' || inputs.cache }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,7 +354,6 @@ jobs:
                     issuer = "https://token.actions.githubusercontent.com"
                     runnerEnvironment = "github-hosted"
                     sourceRepositoryURI = "${{ github.server_url }}/${{ github.repository }}"
-                    sourceRepositoryRef = "${{ github.event_name != 'pull_request' && github.ref || '' }}"
       -
         name: Install Cosign
         if: ${{ needs.prepare.outputs.sign == 'true' || inputs.cache }}


### PR DESCRIPTION
relates to https://github.com/docker/buildx/actions/runs/21013705824/job/60415574773#step:10:438

```
GitHub Actions runtime token ACs
  refs/heads/refs/tags/v0.31.0-rc1: read/write
  refs/heads/master: read
```

```
#14 importing cache manifest from gha:1932265791860608726
#14 verifying signature of cache index sha256:bc497e99d46b2f6628634a3f1569e66ed3575cdbe92539e837967332355c3f3f
#14 verifying signature of cache index sha256:bc497e99d46b2f6628634a3f1569e66ed3575cdbe92539e837967332355c3f3f 0.3s done
#14 ERROR: signature verification failed: certificate field "sourceRepositoryRef" does not match policy ("refs/heads/master" != "refs/tags/v0.31.0-rc1")
```