### PR TITLE
ci: don't run tests on tag events

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - 'main'
       - 'releases/v*'
-    tags:
-      - 'v*'
     paths:
       - '.github/workflows/.test-bake.yml'
       - '.github/workflows/bake.yml'

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - 'main'
       - 'releases/v*'
-    tags:
-      - 'v*'
     paths:
       - '.github/workflows/.test-build.yml'
       - '.github/workflows/build.yml'


### PR DESCRIPTION
Not needed, we already do it on pr and push on default branch.