### PR TITLE
add registry-login input for optional registry auth before build

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -645,3 +645,25 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  bake-local-login:
+    uses: ./.github/workflows/bake.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-name: bake-login-output
+      artifact-upload: true
+      context: test
+      output: local
+      registry-login: true
+      sbom: true
+      sign: true
+      target: dhi
+    secrets:
+      registry-auths: |
+        - registry: dhi.io
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
+          scope: 'dhi.io@pull'

--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -667,3 +667,25 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  bake-local-login:
+    uses: ./.github/workflows/bake.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-name: bake-login-output
+      artifact-upload: true
+      context: test
+      output: local
+      registry-login: true
+      sbom: true
+      sign: true
+      target: dhi
+    secrets:
+      registry-auths: |
+        - registry: dhi.io
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
+          scope: 'dhi.io@pull'

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -664,3 +664,24 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  build-local-login:
+    uses: ./.github/workflows/build.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-name: build-login-output
+      artifact-upload: true
+      file: test/dhi.Dockerfile
+      output: local
+      registry-login: true
+      sbom: true
+      sign: true
+    secrets:
+      registry-auths: |
+        - registry: dhi.io
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
+          scope: 'dhi.io@pull'

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -685,3 +685,24 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  build-local-login:
+    uses: ./.github/workflows/build.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-name: build-login-output
+      artifact-upload: true
+      file: test/dhi.Dockerfile
+      output: local
+      registry-login: true
+      sbom: true
+      sign: true
+    secrets:
+      registry-auths: |
+        - registry: dhi.io
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
+          scope: 'dhi.io@pull'

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -65,6 +65,11 @@ on:
         description: "Push image to the registry (for image output)"
         required: false
         default: false
+      registry-login:
+        type: string
+        description: "Login to registry before build (one of auto, true or false). Auto enables login only when output is image and push is true"
+        required: false
+        default: auto
       sbom:
         type: boolean
         description: "Generate SBOM attestation for the build"
@@ -125,7 +130,7 @@ on:
         required: false
     secrets:
       registry-auths:
-        description: "Raw authentication to registries, defined as YAML objects (for image output)"
+        description: "Raw authentication to registries, defined as YAML objects"
         required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
@@ -173,6 +178,7 @@ jobs:
       metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
+      registryLogin: ${{ steps.set.outputs.registryLogin }}
     steps:
       -
         name: Install dependencies
@@ -260,6 +266,7 @@ jobs:
           INPUT_FILES: ${{ inputs.files }}
           INPUT_OUTPUT: ${{ inputs.output }}
           INPUT_PUSH: ${{ inputs.push }}
+          INPUT_REGISTRY-LOGIN: ${{ inputs.registry-login }}
           INPUT_SBOM: ${{ inputs.sbom }}
           INPUT_SET: ${{ inputs.set }}
           INPUT_SIGN: ${{ inputs.sign }}
@@ -287,6 +294,7 @@ jobs:
             const inpFiles = Util.getInputList('files');
             const inpOutput = core.getInput('output');
             const inpPush = core.getBooleanInput('push');
+            const inpRegistryLogin = core.getInput('registry-login');
             const inpSbom = core.getBooleanInput('sbom');
             const inpSet = Util.getInputList('set', {ignoreComma: true, quote: false});
             const inpSign = core.getInput('sign');
@@ -317,11 +325,17 @@ jobs:
               core.setFailed(`signing attestation manifests requires push to be enabled`);
               return;
             }
-
+            
             const bakeSource = await new Build().gitContext({subdir: inpContext});
             await core.group(`Set bake source`, async () => {
               core.info(bakeSource);
             });
+            
+            if (!['auto', 'true', 'false'].includes(inpRegistryLogin)) {
+              core.setFailed(`Invalid registry-login input: ${inpRegistryLogin}`);
+              return;
+            }
+            const registryLogin = inpRegistryLogin === 'auto' ? inpOutput === 'image' && inpPush : inpRegistryLogin === 'true';
             
             const envs = Object.assign({},
               inpVars ? inpVars.reduce((acc, curr) => {
@@ -339,13 +353,13 @@ jobs:
             await core.group(`Set envs`, async () => {
               core.info(JSON.stringify(envs, null, 2));
             });
-
+            
             const metaImages = inpMetaImages.map(image => image.toLowerCase());
             await core.group(`Set metaImages output`, async () => {
               core.info(JSON.stringify(metaImages, null, 2));
               core.setOutput('metaImages', metaImages.join('\n'));
             });
-
+            
             let def;
             let target;
             try {
@@ -414,7 +428,7 @@ jobs:
               core.setFailed(`Platforms to build exceed matrix size limit of ${inpMatrixSizeLimit}`);
               return;
             }
-
+            
             const privateRepo = GitHub.context.payload.repository?.private ?? false;
             await core.group(`Set privateRepo output`, async () => {
               core.info(`privateRepo: ${privateRepo}`);
@@ -448,6 +462,10 @@ jobs:
               const ghaCacheSign = inpActionsIdTokenSet ? 'true' : 'false';
               core.info(`ghaCacheSign: ${ghaCacheSign}`);
               core.setOutput('ghaCacheSign', ghaCacheSign);
+            });
+            await core.group(`Set registryLogin output`, async () => {
+              core.info(`registryLogin: ${registryLogin}`);
+              core.setOutput('registryLogin', registryLogin);
             });
 
   build:
@@ -791,7 +809,7 @@ jobs:
             });
       -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ needs.prepare.outputs.registryLogin == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -68,6 +68,11 @@ on:
         description: "Push image to the registry (for image output)"
         required: false
         default: false
+      registry-login:
+        type: string
+        description: "Login to registry before build (one of auto, true or false). Auto enables login only when output is image and push is true"
+        required: false
+        default: auto
       sbom:
         type: boolean
         description: "Generate SBOM attestation for the build"
@@ -128,7 +133,7 @@ on:
         required: false
     secrets:
       registry-auths:
-        description: "Raw authentication to registries, defined as YAML objects (for image output)"
+        description: "Raw authentication to registries, defined as YAML objects"
         required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
@@ -185,6 +190,7 @@ jobs:
       metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
+      registryLogin: ${{ steps.set.outputs.registryLogin }}
     steps:
       -
         name: Install dependencies
@@ -283,6 +289,7 @@ jobs:
           INPUT_FILES: ${{ inputs.files }}
           INPUT_OUTPUT: ${{ inputs.output }}
           INPUT_PUSH: ${{ inputs.push }}
+          INPUT_REGISTRY-LOGIN: ${{ inputs.registry-login }}
           INPUT_SBOM: ${{ inputs.sbom }}
           INPUT_SET: ${{ inputs.set }}
           INPUT_SIGN: ${{ inputs.sign }}
@@ -310,6 +317,7 @@ jobs:
             const inpFiles = Util.getInputList('files');
             const inpOutput = core.getInput('output');
             const inpPush = core.getBooleanInput('push');
+            const inpRegistryLogin = core.getInput('registry-login');
             const inpSbom = core.getBooleanInput('sbom');
             const inpSet = Util.getInputList('set', {ignoreComma: true, quote: false});
             const inpSign = core.getInput('sign');
@@ -439,7 +447,13 @@ jobs:
             await core.group(`Set bake source`, async () => {
               core.info(bakeSource);
             });
-            
+
+            if (!['auto', 'true', 'false'].includes(inpRegistryLogin)) {
+              core.setFailed(`Invalid registry-login input: ${inpRegistryLogin}`);
+              return;
+            }
+            const registryLogin = inpRegistryLogin === 'auto' ? inpOutput === 'image' && inpPush : inpRegistryLogin === 'true';
+
             const envs = Object.assign({},
               inpVars ? inpVars.reduce((acc, curr) => {
                 const idx = curr.indexOf('=');
@@ -525,7 +539,7 @@ jobs:
               core.setFailed(error);
               return;
             }
-            
+
             const platforms = def.target[target].platforms || [];
             if (inpDistribute && platforms.length > inpMatrixSizeLimit) {
               core.setFailed(`Platforms to build exceed matrix size limit of ${inpMatrixSizeLimit}`);
@@ -565,6 +579,10 @@ jobs:
               const ghaCacheSign = actionsIdTokenSet ? 'true' : 'false';
               core.info(`ghaCacheSign: ${ghaCacheSign}`);
               core.setOutput('ghaCacheSign', ghaCacheSign);
+            });
+            await core.group(`Set registryLogin output`, async () => {
+              core.info(`registryLogin: ${registryLogin}`);
+              core.setOutput('registryLogin', registryLogin);
             });
 
   build:
@@ -954,7 +972,7 @@ jobs:
             });
       -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ needs.prepare.outputs.registryLogin == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,11 @@ on:
         description: "Push image to the registry (for image output)"
         required: false
         default: false
+      registry-login:
+        type: string
+        description: "Login to registry before build (one of auto, true or false). Auto enables login only when output is image and push is true"
+        required: false
+        default: auto
       sbom:
         type: boolean
         description: "Generate SBOM attestation for the build"
@@ -128,7 +133,7 @@ on:
         required: false
     secrets:
       registry-auths:
-        description: "Raw authentication to registries, defined as YAML objects (for image output)"
+        description: "Raw authentication to registries, defined as YAML objects"
         required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
@@ -177,6 +182,7 @@ jobs:
       sign: ${{ steps.set.outputs.sign }}
       privateRepo: ${{ steps.set.outputs.privateRepo }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
+      registryLogin: ${{ steps.set.outputs.registryLogin }}
     steps:
       -
         name: Install dependencies
@@ -254,6 +260,7 @@ jobs:
           INPUT_OUTPUT: ${{ inputs.output }}
           INPUT_PLATFORMS: ${{ inputs.platforms }}
           INPUT_PUSH: ${{ inputs.push }}
+          INPUT_REGISTRY-LOGIN: ${{ inputs.registry-login }}
           INPUT_SIGN: ${{ inputs.sign }}
         with:
           script: |
@@ -270,6 +277,7 @@ jobs:
             const inpPlatforms = Util.getInputList('platforms');
             const inpOutput = core.getInput('output');
             const inpPush = core.getBooleanInput('push');
+            const inpRegistryLogin = core.getInput('registry-login');
             const inpSign = core.getInput('sign');
             
             let runner = inpRunner;
@@ -296,6 +304,12 @@ jobs:
               core.setFailed(`signing attestation manifests requires push to be enabled`);
               return;
             }
+            
+            if (!['auto', 'true', 'false'].includes(inpRegistryLogin)) {
+              core.setFailed(`Invalid registry-login input: ${inpRegistryLogin}`);
+              return;
+            }
+            const registryLogin = inpRegistryLogin === 'auto' ? inpOutput === 'image' && inpPush : inpRegistryLogin === 'true';
             
             if (inpDistribute && inpPlatforms.length > inpMatrixSizeLimit) {
               core.setFailed(`Platforms to build exceed matrix size limit of ${inpMatrixSizeLimit}`);
@@ -341,6 +355,10 @@ jobs:
               const ghaCacheSign = inpActionsIdTokenSet ? 'true' : 'false';
               core.info(`ghaCacheSign: ${ghaCacheSign}`);
               core.setOutput('ghaCacheSign', ghaCacheSign);
+            });
+            await core.group(`Set registryLogin output`, async () => {
+              core.info(`registryLogin: ${registryLogin}`);
+              core.setOutput('registryLogin', registryLogin);
             });
 
   build:
@@ -649,7 +667,7 @@ jobs:
             }
       -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ needs.prepare.outputs.registryLogin == 'true' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,11 @@ on:
         description: "Push image to the registry (for image output)"
         required: false
         default: false
+      registry-login:
+        type: string
+        description: "Login to registry before build (one of auto, true or false). Auto enables login only when output is image and push is true"
+        required: false
+        default: auto
       sbom:
         type: boolean
         description: "Generate SBOM attestation for the build"
@@ -131,7 +136,7 @@ on:
         required: false
     secrets:
       registry-auths:
-        description: "Raw authentication to registries, defined as YAML objects (for image output)"
+        description: "Raw authentication to registries, defined as YAML objects"
         required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
@@ -189,6 +194,7 @@ jobs:
       sign: ${{ steps.set.outputs.sign }}
       privateRepo: ${{ steps.set.outputs.privateRepo }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
+      registryLogin: ${{ steps.set.outputs.registryLogin }}
     steps:
       -
         name: Install dependencies
@@ -277,6 +283,7 @@ jobs:
           INPUT_OUTPUT: ${{ inputs.output }}
           INPUT_PLATFORMS: ${{ inputs.platforms }}
           INPUT_PUSH: ${{ inputs.push }}
+          INPUT_REGISTRY-LOGIN: ${{ inputs.registry-login }}
           INPUT_SIGN: ${{ inputs.sign }}
         with:
           script: |
@@ -293,6 +300,7 @@ jobs:
             const inpPlatforms = Util.getInputList('platforms');
             const inpOutput = core.getInput('output');
             const inpPush = core.getBooleanInput('push');
+            const inpRegistryLogin = core.getInput('registry-login');
             const inpSign = core.getInput('sign');
             
             const parseRunnerConfig = value => {
@@ -412,7 +420,13 @@ jobs:
               core.setFailed(`signing attestation manifests requires push to be enabled`);
               return;
             }
-            
+
+            if (!['auto', 'true', 'false'].includes(inpRegistryLogin)) {
+              core.setFailed(`Invalid registry-login input: ${inpRegistryLogin}`);
+              return;
+            }
+            const registryLogin = inpRegistryLogin === 'auto' ? inpOutput === 'image' && inpPush : inpRegistryLogin === 'true';
+
             if (inpDistribute && inpPlatforms.length > inpMatrixSizeLimit) {
               core.setFailed(`Platforms to build exceed matrix size limit of ${inpMatrixSizeLimit}`);
               return;
@@ -457,6 +471,10 @@ jobs:
               const ghaCacheSign = actionsIdTokenSet ? 'true' : 'false';
               core.info(`ghaCacheSign: ${ghaCacheSign}`);
               core.setOutput('ghaCacheSign', ghaCacheSign);
+            });
+            await core.group(`Set registryLogin output`, async () => {
+              core.info(`registryLogin: ${registryLogin}`);
+              core.setOutput('registryLogin', registryLogin);
             });
 
   build:
@@ -812,7 +830,7 @@ jobs:
             }
       -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ needs.prepare.outputs.registryLogin == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ jobs:
 | `output`               | String   |                                | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/)). Unlike the `build-push-action`, it only accepts `image` or `local`. The reusable workflow takes care of setting the `outputs` attribute                        |
 | `platforms`            | List/CSV |                                | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) to build                                                                                                                                                                                                                      |
 | `push`                 | Bool     | `false`                        | [Push](https://docs.docker.com/engine/reference/commandline/buildx_build/#push) image to the registry (for `image` output)                                                                                                                                                                                                            |
+| `registry-login`       | String   | `auto`                         | Login to registry before build (one of `auto`, `true` or `false`). `auto` enables login only when output is `image` and push is `true`                                                                                                                                                                                                |
 | `sbom`                 | Bool     | `false`                        | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                                                           |
 | `shm-size`             | String   |                                | Size of [`/dev/shm`](https://docs.docker.com/engine/reference/commandline/buildx_build/#shm-size) (e.g., `2g`)                                                                                                                                                                                                                        |
 | `sign`                 | String   | `auto`                         | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact                                  |
@@ -249,6 +250,16 @@ jobs:
 | `meta-images`          | List     |                                | [List of images](https://github.com/docker/metadata-action?tab=readme-ov-file#images-input) to use as base name for tags (required for image output)                                                                                                                                                                                  |
 | `meta-tags`            | List     |                                | [List of tags](https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input) as key-value pair attributes                                                                                                                                                                                                                  |
 | `meta-flavor`          | List     |                                | [Flavor](https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input) defines a global behavior for `meta-tags`                                                                                                                                                                                                         |
+
+> [!NOTE]
+> `registry-login: true` forces a pre-build login attempt and will fail if the
+> resolved credentials are empty, for example, on forked pull requests where
+> secrets are not exposed. Gate this input at the caller side if you need
+> fork-safe behavior:
+>
+> ```yaml
+> registry-login: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+> ```
 
 > [!TIP]
 > When `output=image`, following inputs support Handlebars templates rendered
@@ -275,10 +286,10 @@ jobs:
 
 #### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| Name             | Default               | Description                                                                                                    |
+|------------------|-----------------------|----------------------------------------------------------------------------------------------------------------|
+| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (used for push/signing and optional pre-build login) |
+| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context                                       |
 
 #### Outputs
 
@@ -384,6 +395,7 @@ jobs:
 | `files`                | List   | `{context}/docker-bake.hcl`    | List of bake definition files                                                                                                                                                                                                                                                                                                         |
 | `output`               | String |                                | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/)).                                                                                                                                                                |
 | `push`                 | Bool   | `false`                        | Push image to the registry (for `image` output)                                                                                                                                                                                                                                                                                       |
+| `registry-login`       | String | `auto`                         | Login to registry before build (one of `auto`, `true` or `false`). `auto` enables login only when output is `image` and push is `true`                                                                                                                                                                                                |
 | `sbom`                 | Bool   | `false`                        | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                                                           |
 | `set`                  | List   |                                | List of [target values to override](https://docs.docker.com/engine/reference/commandline/buildx_bake/#set) (e.g., `targetpattern.key=value`)                                                                                                                                                                                          |
 | `sign`                 | String | `auto`                         | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact                                  |
@@ -396,6 +408,16 @@ jobs:
 | `meta-labels`          | List   |                                | [List of custom labels](https://github.com/docker/metadata-action?tab=readme-ov-file#overwrite-labels-and-annotations)                                                                                                                                                                                                                |
 | `meta-annotations`     | List   |                                | [List of custom annotations](https://github.com/docker/metadata-action?tab=readme-ov-file#overwrite-labels-and-annotations)                                                                                                                                                                                                           |
 | `meta-flavor`          | List   |                                | [Flavor](https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input) defines a global behavior for `meta-tags`                                                                                                                                                                                                         |
+
+> [!NOTE]
+> `registry-login: true` forces a pre-build login attempt and will fail if the
+> resolved credentials are empty, for example, on forked pull requests where
+> secrets are not exposed. Gate this input at the caller side if you need
+> fork-safe behavior:
+>
+> ```yaml
+> registry-login: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+> ```
 
 > [!TIP]
 > When `output=image`, the `set` input supports Handlebars templates rendered
@@ -419,10 +441,10 @@ jobs:
 
 #### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| Name             | Default               | Description                                                                                                    |
+|------------------|-----------------------|----------------------------------------------------------------------------------------------------------------|
+| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (used for push/signing and optional pre-build login) |
+| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context                                       |
 
 #### Outputs
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ___
 * [Notes](#notes)
   * [Signed GitHub Actions cache](#signed-github-actions-cache)
   * [Runner mapping](#runner-mapping)
+  * [Registry login](#registry-login)
   * [Metadata templates](#metadata-templates)
 
 ## Overview
@@ -233,6 +234,7 @@ jobs:
 | `output`               | String   |                                       | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/)). Unlike the `build-push-action`, it only accepts `image` or `local`. The reusable workflow takes care of setting the `outputs` attribute |
 | `platforms`            | List/CSV |                                       | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) to build                                                                                                                                                                                               |
 | `push`                 | Bool     | `false`                               | [Push](https://docs.docker.com/engine/reference/commandline/buildx_build/#push) image to the registry (for `image` output)                                                                                                                                                                                     |
+| `registry-login`       | String   | `auto`                                | [Login to registry](#registry-login) before build (one of `auto`, `true` or `false`)                                                                                                                                                                                                                           |
 | `sbom`                 | Bool     | `false`                               | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                                    |
 | `shm-size`             | String   |                                       | Size of [`/dev/shm`](https://docs.docker.com/engine/reference/commandline/buildx_build/#shm-size) (e.g., `2g`)                                                                                                                                                                                                 |
 | `sign`                 | String   | `auto`                                | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact           |
@@ -246,10 +248,10 @@ jobs:
 
 ### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| Name             | Default               | Description                                                              |
+|------------------|-----------------------|--------------------------------------------------------------------------|
+| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects                |
+| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context |
 
 ### Outputs
 
@@ -338,8 +340,9 @@ jobs:
 | `cache-mode`           | String | `min`                                 | [Cache layers to export](https://docs.docker.com/build/cache/backends/#cache-mode) if cache enabled (`min` or `max`). In `min` cache mode, only layers that are exported into the resulting image are cached, while in `max` cache mode, all layers are cached, even those of intermediate steps     |
 | `context`              | String | `.`                                   | Context to build from in the Git working tree                                                                                                                                                                                                                                                        |
 | `files`                | List   | `{context}/docker-bake.hcl`           | List of bake definition files                                                                                                                                                                                                                                                                        |
-| `output`               | String |                                       | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/)).                                                                                                                               |
+| `output`               | String |                                       | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/))                                                                                                                                |
 | `push`                 | Bool   | `false`                               | Push image to the registry (for `image` output)                                                                                                                                                                                                                                                      |
+| `registry-login`       | String | `auto`                                | [Login to registry](#registry-login) before build (one of `auto`, `true` or `false`)                                                                                                                                                                                                                 |
 | `sbom`                 | Bool   | `false`                               | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                          |
 | `set`                  | List   |                                       | List of [target values to override](https://docs.docker.com/engine/reference/commandline/buildx_bake/#set) (e.g., `targetpattern.key=value`)                                                                                                                                                         |
 | `sign`                 | String | `auto`                                | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact |
@@ -355,10 +358,10 @@ jobs:
 
 ### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| Name             | Default               | Description                                                              |
+|------------------|-----------------------|--------------------------------------------------------------------------|
+| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects                |
+| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context |
 
 ### Outputs
 
@@ -421,6 +424,21 @@ runner: |
 
 For example, `linux` matches all Linux platforms, `linux/arm` matches variants
 such as `linux/arm/v7`, and `linux/arm64` is separate from `linux/arm`.
+
+### Registry login
+
+The `registry-login` input controls whether the workflows run a registry login
+before the build step. `auto` preserves the existing behavior and enables login
+only when `output=image` and `push=true`.
+
+When `registry-login=true`, the workflow always attempts pre-build login. If
+credentials resolve to empty values, for example on forked pull requests where
+secrets are not exposed, login fails. Gate the input at the caller side for
+fork-safe workflows:
+
+```yaml
+registry-login: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+```
 
 ### Metadata templates
 

--- a/test/dhi.Dockerfile
+++ b/test/dhi.Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+
+FROM dhi.io/alpine-base:3.23 AS base
+ARG TARGETPLATFORM
+RUN echo "Hello, World! This is ${TARGETPLATFORM}" > /tmp/hello.txt
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
+FROM scratch
+COPY --from=base /tmp/hello.txt /

--- a/test/docker-bake.hcl
+++ b/test/docker-bake.hcl
@@ -67,3 +67,8 @@ target "generated-hello2" {
   dockerfile = "hello.Dockerfile"
   output = ["type=cacheonly"]
 }
+
+target "dhi" {
+  inherits = ["docker-metadata-action"]
+  dockerfile = "dhi.Dockerfile"
+}


### PR DESCRIPTION
* fixes https://github.com/docker/github-builder/issues/97
* fixes https://github.com/docker/github-builder/issues/116

This PR adds a `registry-login` input to both reusable workflows to control whether registry login happens before the build step. The input supports `auto`, `true`, and `false`:

- `auto` preserves the current behavior and enables login only when `output=image` and `push=true`
- `true` always attempts a pre-build login
- `false` disables pre-build login

This makes pre-build registry authentication available for cases such as local output or non-push builds, while keeping the default behavior unchanged.