### PR TITLE
normalize meta-images for build and bake

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -621,3 +621,27 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  bake-ghcr-image-casing:
+    uses: ./.github/workflows/bake.yml
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      context: test
+      output: image
+      push: ${{ github.event_name != 'pull_request' }}
+      sbom: true
+      set: |
+        *.args.VERSION={{meta.version}}
+      target: hello-cross
+      set-meta-annotations: true
+      meta-images: ghcr.io/docker/GitHub-Builder-Test
+      meta-tags: |
+        type=raw,value=bake-image-casing-${{ github.run_id }}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -640,3 +640,27 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  build-ghcr-image-casing:
+    uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      build-args: |
+        VERSION={{meta.version}}
+      file: test/hello.Dockerfile
+      output: image
+      platforms: linux/amd64,linux/arm64
+      push: ${{ github.event_name != 'pull_request' }}
+      sbom: true
+      set-meta-annotations: true
+      meta-images: ghcr.io/docker/GitHub-Builder-Test
+      meta-tags: |
+        type=raw,value=build-image-casing-${{ github.run_id }}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -170,6 +170,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       includes: ${{ steps.set.outputs.includes }}
+      metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
     steps:
@@ -251,6 +252,7 @@ jobs:
           INPUT_SBOM-IMAGE: ${{ env.SBOM_IMAGE }}
           INPUT_MATRIX-SIZE-LIMIT: ${{ env.MATRIX_SIZE_LIMIT }}
           INPUT_ACTIONS-ID-TOKEN-SET:  ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' && env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}
+          INPUT_META-IMAGES: ${{ inputs.meta-images }}
           INPUT_RUNNER: ${{ inputs.runner }}
           INPUT_DISTRIBUTE: ${{ inputs.distribute }}
           INPUT_ARTIFACT-UPLOAD: ${{ inputs.artifact-upload }}
@@ -275,6 +277,7 @@ jobs:
             const inpSbomImage = core.getInput('sbom-image');
             const inpMatrixSizeLimit = parseInt(core.getInput('matrix-size-limit'), 10);
             const inpActionsIdTokenSet = core.getBooleanInput('actions-id-token-set');
+            const inpMetaImages = core.getMultilineInput('meta-images');
             
             const inpRunner = core.getInput('runner');
             const inpDistribute = core.getBooleanInput('distribute');
@@ -335,6 +338,12 @@ jobs:
             );
             await core.group(`Set envs`, async () => {
               core.info(JSON.stringify(envs, null, 2));
+            });
+
+            const metaImages = inpMetaImages.map(image => image.toLowerCase());
+            await core.group(`Set metaImages output`, async () => {
+              core.info(JSON.stringify(metaImages, null, 2));
+              core.setOutput('metaImages', metaImages.join('\n'));
             });
 
             let def;
@@ -494,7 +503,7 @@ jobs:
         if: ${{ inputs.output == 'image' }}
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ inputs.meta-images }}
+          images: ${{ needs.prepare.outputs.metaImages }}
           tags: ${{ inputs.meta-tags }}
           flavor: ${{ inputs.meta-flavor }}
           labels: ${{ inputs.meta-labels }}
@@ -632,7 +641,7 @@ jobs:
           INPUT_SET: ${{ inputs.set }}
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_VARS: ${{ inputs.vars }}
-          INPUT_META-IMAGES: ${{ inputs.meta-images }}
+          INPUT_META-IMAGES: ${{ needs.prepare.outputs.metaImages }}
           INPUT_META-VERSION: ${{ steps.meta.outputs.version }}
           INPUT_META-TAGS: ${{ steps.meta.outputs.tags }}
           INPUT_SET-META-ANNOTATIONS: ${{ inputs.set-meta-annotations }}
@@ -826,7 +835,7 @@ jobs:
         if: ${{ needs.prepare.outputs.sign == 'true' && inputs.output == 'image' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
-          INPUT_IMAGE-NAMES: ${{ inputs.meta-images }}
+          INPUT_IMAGE-NAMES: ${{ needs.prepare.outputs.metaImages }}
           INPUT_IMAGE-DIGEST: ${{ steps.get-image-digest.outputs.digest }}
         with:
           script: |
@@ -958,7 +967,7 @@ jobs:
         if: ${{ inputs.output == 'image' }}
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ inputs.meta-images }}
+          images: ${{ needs.prepare.outputs.metaImages }}
           tags: ${{ inputs.meta-tags }}
           flavor: ${{ inputs.meta-flavor }}
           labels: ${{ inputs.meta-labels }}
@@ -988,7 +997,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_PUSH: ${{ inputs.push }}
-          INPUT_IMAGE-NAMES: ${{ inputs.meta-images }}
+          INPUT_IMAGE-NAMES: ${{ needs.prepare.outputs.metaImages }}
           INPUT_TAG-NAMES: ${{ steps.meta.outputs.tag-names }}
           INPUT_BUILD-OUTPUTS: ${{ toJSON(needs.build.outputs) }}
           INPUT_SET-META-ANNOTATIONS: ${{ inputs.set-meta-annotations }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       includes: ${{ steps.set.outputs.includes }}
+      metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
       privateRepo: ${{ steps.set.outputs.privateRepo }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
@@ -246,6 +247,7 @@ jobs:
         env:
           INPUT_MATRIX-SIZE-LIMIT: ${{ env.MATRIX_SIZE_LIMIT }}
           INPUT_ACTIONS-ID-TOKEN-SET:  ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' && env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}
+          INPUT_META-IMAGES: ${{ inputs.meta-images }}
           INPUT_RUNNER: ${{ inputs.runner }}
           INPUT_DISTRIBUTE: ${{ inputs.distribute }}
           INPUT_ARTIFACT-UPLOAD: ${{ inputs.artifact-upload }}
@@ -260,6 +262,7 @@ jobs:
             
             const inpMatrixSizeLimit = parseInt(core.getInput('matrix-size-limit'), 10);
             const inpActionsIdTokenSet = core.getBooleanInput('actions-id-token-set');
+            const inpMetaImages = core.getMultilineInput('meta-images');
             
             const inpRunner = core.getInput('runner');
             const inpDistribute = core.getBooleanInput('distribute');
@@ -303,6 +306,12 @@ jobs:
             await core.group(`Set privateRepo output`, async () => {
               core.info(`privateRepo: ${privateRepo}`);
               core.setOutput('privateRepo', privateRepo);
+            });
+
+            const metaImages = inpMetaImages.map(image => image.toLowerCase());
+            await core.group(`Set metaImages output`, async () => {
+              core.info(JSON.stringify(metaImages, null, 2));
+              core.setOutput('metaImages', metaImages.join('\n'));
             });
             
             await core.group(`Set includes output`, async () => {
@@ -387,7 +396,7 @@ jobs:
         if: ${{ inputs.output == 'image' }}
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ inputs.meta-images }}
+          images: ${{ needs.prepare.outputs.metaImages }}
           tags: ${{ inputs.meta-tags }}
           flavor: ${{ inputs.meta-flavor }}
           labels: ${{ inputs.meta-labels }}
@@ -526,7 +535,7 @@ jobs:
           INPUT_PUSH: ${{ inputs.push }}
           INPUT_SBOM: ${{ inputs.sbom }}
           INPUT_TARGET: ${{ inputs.target }}
-          INPUT_META-IMAGES: ${{ inputs.meta-images }}
+          INPUT_META-IMAGES: ${{ needs.prepare.outputs.metaImages }}
           INPUT_META-VERSION: ${{ steps.meta.outputs.version }}
           INPUT_META-TAGS: ${{ steps.meta.outputs.tags }}
           INPUT_SET-META-ANNOTATIONS: ${{ inputs.set-meta-annotations }}
@@ -681,7 +690,7 @@ jobs:
         if: ${{ needs.prepare.outputs.sign == 'true' && inputs.output == 'image' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
-          INPUT_IMAGE-NAMES: ${{ inputs.meta-images }}
+          INPUT_IMAGE-NAMES: ${{ needs.prepare.outputs.metaImages }}
           INPUT_IMAGE-DIGEST: ${{ steps.build.outputs.digest }}
         with:
           script: |
@@ -813,7 +822,7 @@ jobs:
         if: ${{ inputs.output == 'image' }}
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ inputs.meta-images }}
+          images: ${{ needs.prepare.outputs.metaImages }}
           tags: ${{ inputs.meta-tags }}
           flavor: ${{ inputs.meta-flavor }}
           labels: ${{ inputs.meta-labels }}
@@ -842,7 +851,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_PUSH: ${{ inputs.push }}
-          INPUT_IMAGE-NAMES: ${{ inputs.meta-images }}
+          INPUT_IMAGE-NAMES: ${{ needs.prepare.outputs.metaImages }}
           INPUT_TAG-NAMES: ${{ steps.meta.outputs.tag-names }}
           INPUT_BUILD-OUTPUTS: ${{ toJSON(needs.build.outputs) }}
           INPUT_ANNOTATIONS: ${{ inputs.annotations }}


### PR DESCRIPTION
fixes #163 

It's now normalizing `meta-images` to lowercase before any image build or bake logic consumes it similar to what `metadata-action` currently does.

See https://github.com/docker/github-builder/actions/runs/24343232874/job/71077173908#step:7:239