### PR TITLE
require GitHub-hosted runners in reusable build jobs

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -474,6 +474,17 @@ jobs:
       result_19: ${{ steps.result.outputs.result_19 }}
     steps:
       -
+        name: Require GitHub-hosted runner
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          INPUT_RUNNER-ENVIRONMENT: ${{ runner.environment }}
+        with:
+          script: |
+            const runnerEnvironment = core.getInput('runner-environment');
+            if (runnerEnvironment !== 'github-hosted') {
+              core.setFailed(`This workflow requires a GitHub-hosted runner, got: ${runnerEnvironment || 'unknown'}`);
+            }
+      -
         name: Install dependencies
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,6 +367,17 @@ jobs:
       result_19: ${{ steps.result.outputs.result_19 }}
     steps:
       -
+        name: Require GitHub-hosted runner
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          INPUT_RUNNER-ENVIRONMENT: ${{ runner.environment }}
+        with:
+          script: |
+            const runnerEnvironment = core.getInput('runner-environment');
+            if (runnerEnvironment !== 'github-hosted') {
+              core.setFailed(`This workflow requires a GitHub-hosted runner, got: ${runnerEnvironment || 'unknown'}`);
+            }
+      -
         name: Install dependencies
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:


### PR DESCRIPTION
relates to https://github.com/docker/github-builder/issues/161#issuecomment-4236652220

The change inserts a first step in each matrix build job to read `runner.environment` and fail the job when the value is not `github-hosted`. This leaves the existing runner selection and mapping logic unchanged, and adds a narrow contract check on the runner environment before the rest of the build steps execute.

The current workflows assume a stronger isolation posture than they actually enforce at the job level. Adding this guard makes the GitHub-hosted requirement explicit in the reusable workflow behavior, which keeps the trust boundary tighter while still leaving room to support different GitHub-hosted labels later through constrained mapping.