### PR TITLE
build/bake: use signing config for GHA cache signing

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -555,21 +555,33 @@ jobs:
             set -e
             
             # Create temporary files
-            out_file=$(mktemp)
-            in_file=$(mktemp)
-            trap 'rm -f "$in_file" "$out_file"' EXIT
+            tmp_dir=$(mktemp -d)
+            out_file="$tmp_dir/bundle"
+            in_file="$tmp_dir/blob"
+            signing_config="$tmp_dir/signing-config.json"
+            trap 'rm -rf "$tmp_dir"' EXIT
             cat > "$in_file"
             
+            no_default_rekor=
+            if [ "${{ needs.prepare.outputs.privateRepo }}" = "true" ]; then
+              no_default_rekor="--no-default-rekor=true"
+            fi
+
             set -x
             
+            # Create signing config
+            COSIGN_EXPERIMENTAL=1 cosign signing-config create \
+              --with-default-services=true \
+              ${no_default_rekor:+$no_default_rekor} \
+              --out="$signing_config"
+
             # Sign with cosign
             cosign sign-blob \
               --yes \
               --oidc-provider github-actions \
               --new-bundle-format \
-              --use-signing-config \
+              --signing-config "$signing_config" \
               --bundle "$out_file" \
-              --tlog-upload=${{ needs.prepare.outputs.privateRepo == 'false' }} \
               "$in_file"
             
             # Output bundle to stdout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,21 +447,33 @@ jobs:
             set -e
             
             # Create temporary files
-            out_file=$(mktemp)
-            in_file=$(mktemp)
-            trap 'rm -f "$in_file" "$out_file"' EXIT
+            tmp_dir=$(mktemp -d)
+            out_file="$tmp_dir/bundle"
+            in_file="$tmp_dir/blob"
+            signing_config="$tmp_dir/signing-config.json"
+            trap 'rm -rf "$tmp_dir"' EXIT
             cat > "$in_file"
             
+            no_default_rekor=
+            if [ "${{ needs.prepare.outputs.privateRepo }}" = "true" ]; then
+              no_default_rekor="--no-default-rekor=true"
+            fi
+
             set -x
             
+            # Create signing config
+            COSIGN_EXPERIMENTAL=1 cosign signing-config create \
+              --with-default-services=true \
+              ${no_default_rekor:+$no_default_rekor} \
+              --out="$signing_config"
+
             # Sign with cosign
             cosign sign-blob \
               --yes \
               --oidc-provider github-actions \
               --new-bundle-format \
-              --use-signing-config \
+              --signing-config "$signing_config" \
               --bundle "$out_file" \
-              --tlog-upload=${{ needs.prepare.outputs.privateRepo == 'false' }} \
               "$in_file"
             
             # Output bundle to stdout


### PR DESCRIPTION
follow-up https://github.com/docker/actions-toolkit/pull/931

GitHub Actions cache blob signing fails with cosign `v3.0.4` when BuildKit signs a GitHub Actions cache index.

The generated signing command combines `--use-signing-config` with `--tlog-upload=false`:

```sh
cosign sign-blob \
  --yes \
  --oidc-provider github-actions \
  --new-bundle-format \
  --use-signing-config \
  --bundle "$out_file" \
  --tlog-upload=false \
  "$in_file"
```

Cosign no longer supports disabling transparency log upload with `--tlog-upload=false` when `--use-signing-config` or `--signing-config` is used:

```text
#30 signing cache index sha256:578e247ddaa7e6407cafb755a648345d27e6b60c09be18cf4209115cf4ba9dda
#30 ERROR: signing command failed: + cosign sign-blob --yes --oidc-provider github-actions --new-bundle-format --use-signing-config --bundle /tmp/tmp.CPdLbl '--tlog-upload=false' /tmp/tmp.Kohobl
Flag --tlog-upload has been deprecated, prefer using a --signing-config file with no transparency log services
Error: --tlog-upload=false is not supported with --signing-config or --use-signing-config. Provide a signing config with --signing-config without a transparency log service, which can be created with `cosign signing-config create` or `curl https://raw.githubusercontent.com/sigstore/root-signing/refs/heads/main/targets/signing_config.v0.2.json | jq 'del(.rekorTlogUrls)'` for the public instance
```

The signing config is now expected to define whether transparency log services are available. Passing `--tlog-upload=false` alongside `--use-signing-config` makes cosign fail before it writes the bundle.