### PR TITLE
build/bake: increase npm fetch retries in workflow installs

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -163,6 +163,7 @@ env:
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"
   BUILDX_SEND_GIT_QUERY_AS_INPUT: "true"
+  NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
   prepare:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,7 @@ env:
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"
   BUILDX_SEND_GIT_QUERY_AS_INPUT: "true"
+  NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
   prepare:


### PR DESCRIPTION
relates to https://github.com/docker/github-builder/actions/runs/25382289564/job/74433765810#step:2:30

```
/usr/local/bin/npm install --prefer-offline --ignore-scripts @docker/actions-toolkit@0.89.1
npm error code ECONNRESET
npm error network aborted
npm error network This is a problem related to network connectivity.
npm error network In most cases you are behind a proxy or have bad network settings.
npm error network
npm error network If you are behind a proxy, please make sure that the
npm error network 'proxy' config is set properly.  See: 'npm help config'
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-05-05T14_25_22_862Z-debug-0.log
Error: The process '/usr/local/bin/npm' failed with exit code 1
    at ExecState._setResult (/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:1702:25)
    at ExecState.CheckComplete (/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:1685:18)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:1579:27)
    at ChildProcess.emit (node:events:509:28)
    at maybeClose (node:internal/child_process:1124:16)
    at ChildProcess._handle.onexit (node:internal/child_process:306:5)
Error: Unhandled error: Error: The process '/usr/local/bin/npm' failed with exit code 1
```

Both the build and bake workflows now set `NPM_CONFIG_FETCH_RETRIES` to `5` at workflow scope, which is inherited by the `actions/github-script` steps that run `npm install` for `@docker/actions-toolkit`.

* https://docs.npmjs.com/cli/v11/using-npm/config#fetch-retries
* https://www.npmjs.com/package/make-fetch-happen#--optsretry