### PR TITLE
build/bake: enable fetch-by-commit for git contexts

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -413,8 +413,9 @@ jobs:
               core.setFailed(`signing attestation manifests requires push to be enabled`);
               return;
             }
-
-            const bakeSource = await new Build().gitContext({subdir: inpContext});
+            
+            const gitContextAttrs = GitHub.context.ref.startsWith('refs/tags/') ? {} : {'fetch-by-commit': 'true'};
+            const bakeSource = await new Build().gitContext({subdir: inpContext, attrs: gitContextAttrs});
             await core.group(`Set bake source`, async () => {
               core.info(bakeSource);
             });
@@ -810,7 +811,8 @@ jobs:
             };
             const renderTemplate = value => Util.compileHandlebars(value, {noEscape: true}, {meta});
             
-            const bakeSource = await new Build().gitContext({subdir: inpContext});
+            const gitContextAttrs = GitHub.context.ref.startsWith('refs/tags/') ? {} : {'fetch-by-commit': 'true'};
+            const bakeSource = await new Build().gitContext({subdir: inpContext, attrs: gitContextAttrs});
             await core.group(`Set source output`, async () => {
               core.info(bakeSource);
               core.setOutput('source', bakeSource);

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -703,8 +703,9 @@ jobs:
 
             const renderTemplate = value => Util.compileHandlebars(value, {noEscape: true}, {meta});
             const toMultilineInput = value => value.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
-
-            const buildContext = await new Build().gitContext({subdir: inpContext});
+            
+            const gitContextAttrs = GitHub.context.ref.startsWith('refs/tags/') ? {} : {'fetch-by-commit': 'true'};
+            const buildContext = await new Build().gitContext({subdir: inpContext, attrs: gitContextAttrs});
             core.setOutput('context', buildContext);
             
             switch (inpOutput) {


### PR DESCRIPTION
fixes #194 

The workflow scripts now pass fetch-by-commit=true as a Git context attribute for generated build and bake source contexts, except when the workflow ref is a tag. This keeps the symbolic ref in the Git context URL while pinning the checksum.