### PR TITLE
ci: scope the update dependency app token permissions

### DIFF
--- a/.github/workflows/.update-deps.yml
+++ b/.github/workflows/.update-deps.yml
@@ -39,6 +39,9 @@ jobs:
           private-key: ${{ secrets.DOCKER_GITHUB_BUILDER_WRITE_PRIVATE_KEY }}
           owner: docker
           repositories: github-builder
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
       -
         name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This scopes the GitHub App token used by the dependency update workflow so it no longer inherits the full installation permission set and silence zizmor even if the GitHub App already scopes them.