### PR TITLE
build/bake: pin workflow tool images by digest

### DIFF
--- a/.github/workflows/.update-deps.yml
+++ b/.github/workflows/.update-deps.yml
@@ -103,8 +103,9 @@ jobs:
                     owner: 'moby',
                     repo: 'buildkit'
                   });
+                  const image = `moby/buildkit:${release.data.tag_name}`;
                   return {
-                    value: `moby/buildkit:${release.data.tag_name}`,
+                    value: `${image}@${await resolveImageDigest(image)}`,
                     from: release.data.tag_name,
                     to: release.data.tag_name
                   };
@@ -125,10 +126,12 @@ jobs:
                     repo: 'buildkit-syft-scanner'
                   });
                   const tag = release.data.tag_name;
+                  const imageTag = stripLeadingV(tag);
+                  const image = `docker/buildkit-syft-scanner:${imageTag}`;
                   return {
-                    value: `docker/buildkit-syft-scanner:${stripLeadingV(tag)}`,
+                    value: `${image}@${await resolveImageDigest(image)}`,
                     from: tag,
-                    to: stripLeadingV(tag)
+                    to: imageTag
                   };
                 }
               },
@@ -151,8 +154,9 @@ jobs:
                     throw new Error(`Expected deploy/ release tag for tonistiigi/binfmt, got ${tag}`);
                   }
                   const imageTag = `qemu-${tag.slice('deploy/'.length)}`;
+                  const image = `tonistiigi/binfmt:${imageTag}`;
                   return {
-                    value: `tonistiigi/binfmt:${imageTag}`,
+                    value: `${image}@${await resolveImageDigest(image)}`,
                     from: tag,
                     to: imageTag
                   };
@@ -228,6 +232,20 @@ jobs:
               return Buffer.from(data.content, data.encoding).toString('utf8');
             }
 
+            async function resolveImageDigest(image) {
+              const result = await exec.getExecOutput('docker', ['buildx', 'imagetools', 'inspect', image, '--format', '{{json .Manifest}}'], {
+                silent: true
+              });
+              if (result.exitCode !== 0) {
+                throw new Error(`Failed to inspect ${image}: ${result.stderr}`);
+              }
+              const manifest = JSON.parse(result.stdout);
+              if (!manifest.digest) {
+                throw new Error(`Unable to resolve digest for ${image}`);
+              }
+              return manifest.digest;
+            }
+
             function readEnvValue(content, key) {
               const pattern = new RegExp(`^  ${escapeRegExp(key)}: "([^"]*)"$`, 'm');
               const match = content.match(pattern);
@@ -254,6 +272,10 @@ jobs:
               return [...new Set(values)];
             }
 
+            function stripImageDigest(value) {
+              return value.replace(/@sha256:[a-f0-9]{64}$/i, '');
+            }
+
             function formatList(values) {
               if (values.length === 1) {
                 return `\`${values[0]}\``;
@@ -263,6 +285,10 @@ jobs:
               }
               const quoted = values.map((value) => `\`${value}\``);
               return `${quoted.slice(0, -1).join(', ')}, and ${quoted.at(-1)}`;
+            }
+
+            function formatDisplayList(values) {
+              return formatList(values.map(stripImageDigest));
             }
 
             const config = dependencyConfigs[dep];
@@ -308,7 +334,7 @@ jobs:
               core.info(`No workspace changes needed for ${config.key}`);
             }
 
-            const beforeValue = formatList(baseValues);
+            const beforeValue = formatDisplayList(baseValues);
             const commitMessage = `chore(deps): update ${config.name} to ${target.to}`;
 
             core.setOutput('branch', config.branch);
@@ -316,6 +342,7 @@ jobs:
             core.setOutput('key', config.key);
             core.setOutput('before-value', beforeValue);
             core.setOutput('target-value', target.value);
+            core.setOutput('target-label', target.to);
             core.setOutput('source-url', config.sourceUrl);
       -
         name: Create pull request
@@ -330,6 +357,6 @@ jobs:
           sign-commits: true
           delete-branch: true
           body: |
-            This updates ${{ steps.update.outputs.key }} from ${{ steps.update.outputs.before-value }} to `${{ steps.update.outputs.target-value }}`.
+            This updates ${{ steps.update.outputs.key }} from ${{ steps.update.outputs.before-value }} to `${{ steps.update.outputs.target-label }}`.
 
             The source of truth for this update is ${{ steps.update.outputs.source-url }}.

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -158,9 +158,9 @@ on:
 
 env:
   BUILDX_VERSION: "v0.34.1"
-  BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
-  SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
-  BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
+  BUILDKIT_IMAGE: "moby/buildkit:v0.30.0@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f"
+  SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0@sha256:79e7b013cbec16bbb436f312819a49a4a57752b2270c1a9332ae1a10fcc82a68"
+  BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3"
   DOCKER_ACTIONS_TOOLKIT_MODULE: "@docker/actions-toolkit@0.90.0"
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,9 +161,9 @@ on:
 
 env:
   BUILDX_VERSION: "v0.34.1"
-  BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
-  SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
-  BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
+  BUILDKIT_IMAGE: "moby/buildkit:v0.30.0@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f"
+  SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0@sha256:79e7b013cbec16bbb436f312819a49a4a57752b2270c1a9332ae1a10fcc82a68"
+  BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3"
   DOCKER_ACTIONS_TOOLKIT_MODULE: "@docker/actions-toolkit@0.90.0"
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"


### PR DESCRIPTION
follow-up https://github.com/docker/github-builder/pull/216#pullrequestreview-4362179133

This pins the BuildKit, SBOM scanner, and binfmt container images used by the reusable workflows to immutable image digests.

The build and bake workflows now use `tag@sha256` image references for the tool images. The dependency update workflow now resolves image digests through `docker buildx imagetools inspect --format '{{json .Manifest}}'` and keeps generated dependency PR text readable by showing tag values without digests.

Pinning the reusable workflow alone does not freeze the underlying tool images when those images are referenced only by tag. This change makes the workflow tool image inputs immutable while preserving the existing automated update flow.

cc @stefanprodan