### PR TITLE
use github-builder-runtime package

### DIFF
--- a/.github/workflows/.update-deps.yml
+++ b/.github/workflows/.update-deps.yml
@@ -28,7 +28,7 @@ jobs:
           - sbom
           - binfmt
           - cosign
-          - toolkit
+          - runtime
     steps:
       -
         name: GitHub auth token from GitHub App
@@ -161,26 +161,29 @@ jobs:
                   };
                 }
               },
-              toolkit: {
-                key: 'DOCKER_ACTIONS_TOOLKIT_MODULE',
-                name: 'actions-toolkit module',
-                branch: 'deps/docker-actions-toolkit-module',
+              runtime: {
+                key: 'RUNTIME_MODULE',
+                name: 'github-builder-runtime module',
+                branch: 'deps/docker-github-builder-runtime-module',
                 files: [
                   '.github/workflows/build.yml',
                   '.github/workflows/bake.yml',
                   '.github/workflows/verify.yml'
                 ],
-                sourceUrl: 'https://github.com/docker/actions-toolkit/releases/latest',
-                async resolve({github}) {
-                  const release = await github.rest.repos.getLatestRelease({
-                    owner: 'docker',
-                    repo: 'actions-toolkit'
-                  });
-                  const tag = release.data.tag_name;
-                  const version = stripLeadingV(tag);
+                sourceUrl: 'https://www.npmjs.com/package/@docker/github-builder-runtime',
+                async resolve() {
+                  const response = await fetch('https://registry.npmjs.org/@docker%2fgithub-builder-runtime/latest');
+                  if (!response.ok) {
+                    throw new Error(`Unable to resolve latest @docker/github-builder-runtime package: ${response.status} ${response.statusText}`);
+                  }
+                  const payload = await response.json();
+                  const version = payload?.version;
+                  if (!version) {
+                    throw new Error('Unable to resolve latest @docker/github-builder-runtime package version from npm');
+                  }
                   return {
-                    value: `@docker/actions-toolkit@${version}`,
-                    from: tag,
+                    value: `@docker/github-builder-runtime@${version}`,
+                    from: version,
                     to: version
                   };
                 }

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -161,7 +161,7 @@ env:
   BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
   SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
   BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
-  RUNTIME_MODULE: "@docker/github-builder-runtime@0.90.0"
+  RUNTIME_MODULE: "@docker/github-builder-runtime@0.91.0"
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -162,6 +162,15 @@ env:
   SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
   BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
   RUNTIME_MODULE: "@docker/github-builder-runtime@0.91.0"
+  RUNTIME_INSTALL_ARGS: |
+    --loglevel=error
+    --no-save
+    --package-lock=false
+    --ignore-scripts
+    --omit=dev
+    --prefer-offline
+    --fund=false
+    --audit=false
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"
@@ -182,9 +191,24 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
       -
         name: Install Cosign
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -593,9 +617,24 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
       -
         name: Docker meta
         id: meta
@@ -1082,9 +1121,24 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
       -
         name: Docker meta
         id: meta

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -161,7 +161,7 @@ env:
   BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
   SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
   BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
-  DOCKER_ACTIONS_TOOLKIT_MODULE: "@docker/actions-toolkit@0.90.0"
+  RUNTIME_MODULE: "@docker/github-builder-runtime@0.90.0"
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"
@@ -181,10 +181,10 @@ jobs:
         name: Install dependencies
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_DAT-MODULE: ${{ env.DOCKER_ACTIONS_TOOLKIT_MODULE }}
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--prefer-offline', '--ignore-scripts', core.getInput('dat-module')]);
+            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
       -
         name: Install Cosign
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -192,8 +192,8 @@ jobs:
           INPUT_COSIGN-VERSION: ${{ env.COSIGN_VERSION }}
         with:
           script: |
-            const { Cosign } = require('@docker/actions-toolkit/lib/cosign/cosign');
-            const { Install } = require('@docker/actions-toolkit/lib/cosign/install');
+            const { Cosign } = require('@docker/github-builder-runtime/lib/cosign/cosign');
+            const { Install } = require('@docker/github-builder-runtime/lib/cosign/install');
 
             const inpCosignVersion = core.getInput('cosign-version');
 
@@ -218,8 +218,8 @@ jobs:
             ${{ env.BINFMT_IMAGE }}
         with:
           script: |
-            const { OCI } = require('@docker/actions-toolkit/lib/oci/oci');
-            const { Sigstore } = require('@docker/actions-toolkit/lib/sigstore/sigstore');
+            const { OCI } = require('@docker/github-builder-runtime/lib/oci/oci');
+            const { Sigstore } = require('@docker/github-builder-runtime/lib/sigstore/sigstore');
 
             const sigstore = new Sigstore();
             
@@ -268,10 +268,10 @@ jobs:
         with:
           script: |
             const os = require('os');
-            const { Bake } = require('@docker/actions-toolkit/lib/buildx/bake');
-            const { Build } = require('@docker/actions-toolkit/lib/buildx/build');
-            const { GitHub } = require('@docker/actions-toolkit/lib/github/github');
-            const { Util } = require('@docker/actions-toolkit/lib/util');
+            const { Bake } = require('@docker/github-builder-runtime/lib/buildx/bake');
+            const { Build } = require('@docker/github-builder-runtime/lib/buildx/build');
+            const { GitHub } = require('@docker/github-builder-runtime/lib/github/github');
+            const { Util } = require('@docker/github-builder-runtime/lib/util');
 
             const inpSbomImage = core.getInput('sbom-image');
             const inpMatrixSizeLimit = parseInt(core.getInput('matrix-size-limit'), 10);
@@ -592,15 +592,10 @@ jobs:
         name: Install dependencies
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_DAT-MODULE: ${{ env.DOCKER_ACTIONS_TOOLKIT_MODULE }}
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
         with:
           script: |
-            await exec.exec('npm', [
-              'install',
-              '--prefer-offline',
-              '--ignore-scripts',
-              core.getInput('dat-module')
-            ]);
+            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
       -
         name: Docker meta
         id: meta
@@ -712,9 +707,9 @@ jobs:
             const os = require('os');
             const path = require('path');
             
-            const { Buildx } = require('@docker/actions-toolkit/lib/buildx/buildx');
-            const { Cosign } = require('@docker/actions-toolkit/lib/cosign/cosign');
-            const { Install } = require('@docker/actions-toolkit/lib/cosign/install');
+            const { Buildx } = require('@docker/github-builder-runtime/lib/buildx/buildx');
+            const { Cosign } = require('@docker/github-builder-runtime/lib/cosign/cosign');
+            const { Install } = require('@docker/github-builder-runtime/lib/cosign/install');
             
             const inpCosignVersion = core.getInput('cosign-version');
             const inpBuilderName = core.getInput('builder-name');
@@ -782,9 +777,9 @@ jobs:
         with:
           script: |
             const os = require('os');
-            const { Build } = require('@docker/actions-toolkit/lib/buildx/build');
-            const { GitHub } = require('@docker/actions-toolkit/lib/github/github');
-            const { Util } = require('@docker/actions-toolkit/lib/util');
+            const { Build } = require('@docker/github-builder-runtime/lib/buildx/build');
+            const { GitHub } = require('@docker/github-builder-runtime/lib/github/github');
+            const { Util } = require('@docker/github-builder-runtime/lib/util');
             
             const inpPlatform = core.getInput('platform');
             const platformPairSuffix = inpPlatform ? `-${inpPlatform.replace(/\//g, '-')}` : '';
@@ -968,7 +963,7 @@ jobs:
           INPUT_IMAGE-DIGEST: ${{ steps.get-image-digest.outputs.digest }}
         with:
           script: |
-            const { Sigstore } = require('@docker/actions-toolkit/lib/sigstore/sigstore');
+            const { Sigstore } = require('@docker/github-builder-runtime/lib/sigstore/sigstore');
             
             const inpImageNames = core.getMultilineInput('image-names');
             const inpImageDigest = core.getInput('image-digest');
@@ -1004,7 +999,7 @@ jobs:
         with:
           script: |
             const path = require('path');
-            const { Sigstore } = require('@docker/actions-toolkit/lib/sigstore/sigstore');
+            const { Sigstore } = require('@docker/github-builder-runtime/lib/sigstore/sigstore');
             const inplocalExportDir = core.getInput('local-output-dir');
             
             const sigstore = new Sigstore();
@@ -1086,10 +1081,10 @@ jobs:
         name: Install dependencies
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_DAT-MODULE: ${{ env.DOCKER_ACTIONS_TOOLKIT_MODULE }}
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--prefer-offline', '--ignore-scripts', core.getInput('dat-module')]);
+            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
       -
         name: Docker meta
         id: meta
@@ -1133,7 +1128,7 @@ jobs:
           INPUT_META-ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
         with:
           script: |
-            const { ImageTools } = require('@docker/actions-toolkit/lib/buildx/imagetools');
+            const { ImageTools } = require('@docker/github-builder-runtime/lib/buildx/imagetools');
             
             const inpPush = core.getBooleanInput('push');
             const inpImageNames = core.getMultilineInput('image-names');

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ env:
   BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
   SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
   BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
-  RUNTIME_MODULE: "@docker/github-builder-runtime@0.90.0"
+  RUNTIME_MODULE: "@docker/github-builder-runtime@0.91.0"
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ env:
   BUILDKIT_IMAGE: "moby/buildkit:v0.30.0"
   SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
   BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
-  DOCKER_ACTIONS_TOOLKIT_MODULE: "@docker/actions-toolkit@0.90.0"
+  RUNTIME_MODULE: "@docker/github-builder-runtime@0.90.0"
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"
@@ -185,10 +185,10 @@ jobs:
         name: Install dependencies
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_DAT-MODULE: ${{ env.DOCKER_ACTIONS_TOOLKIT_MODULE }}
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--prefer-offline', '--ignore-scripts', core.getInput('dat-module')]);
+            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
       -
         name: Install Cosign
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -196,8 +196,8 @@ jobs:
           INPUT_COSIGN-VERSION: ${{ env.COSIGN_VERSION }}
         with:
           script: |
-            const { Cosign } = require('@docker/actions-toolkit/lib/cosign/cosign');
-            const { Install } = require('@docker/actions-toolkit/lib/cosign/install');
+            const { Cosign } = require('@docker/github-builder-runtime/lib/cosign/cosign');
+            const { Install } = require('@docker/github-builder-runtime/lib/cosign/install');
 
             const inpCosignVersion = core.getInput('cosign-version');
 
@@ -222,8 +222,8 @@ jobs:
             ${{ env.BINFMT_IMAGE }}
         with:
           script: |
-            const { OCI } = require('@docker/actions-toolkit/lib/oci/oci');
-            const { Sigstore } = require('@docker/actions-toolkit/lib/sigstore/sigstore');
+            const { OCI } = require('@docker/github-builder-runtime/lib/oci/oci');
+            const { Sigstore } = require('@docker/github-builder-runtime/lib/sigstore/sigstore');
 
             const sigstore = new Sigstore();
             
@@ -256,8 +256,8 @@ jobs:
           INPUT_SIGN: ${{ inputs.sign }}
         with:
           script: |
-            const { GitHub } = require('@docker/actions-toolkit/lib/github/github');
-            const { Util } = require('@docker/actions-toolkit/lib/util');
+            const { GitHub } = require('@docker/github-builder-runtime/lib/github/github');
+            const { Util } = require('@docker/github-builder-runtime/lib/util');
             
             const inpMatrixSizeLimit = parseInt(core.getInput('matrix-size-limit'), 10);
             const inpMetaImages = core.getMultilineInput('meta-images');
@@ -484,15 +484,10 @@ jobs:
         name: Install dependencies
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_DAT-MODULE: ${{ env.DOCKER_ACTIONS_TOOLKIT_MODULE }}
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
         with:
           script: |
-            await exec.exec('npm', [
-              'install',
-              '--prefer-offline',
-              '--ignore-scripts',
-              core.getInput('dat-module')
-            ]);
+            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
       -
         name: Docker meta
         id: meta
@@ -603,9 +598,9 @@ jobs:
             const os = require('os');
             const path = require('path');
             
-            const { Buildx } = require('@docker/actions-toolkit/lib/buildx/buildx');
-            const { Cosign } = require('@docker/actions-toolkit/lib/cosign/cosign');
-            const { Install } = require('@docker/actions-toolkit/lib/cosign/install');
+            const { Buildx } = require('@docker/github-builder-runtime/lib/buildx/buildx');
+            const { Cosign } = require('@docker/github-builder-runtime/lib/cosign/cosign');
+            const { Install } = require('@docker/github-builder-runtime/lib/cosign/install');
             
             const inpCosignVersion = core.getInput('cosign-version');
             const inpBuilderName = core.getInput('builder-name');
@@ -672,9 +667,9 @@ jobs:
           INPUT_META-LABELS: ${{ steps.meta.outputs.labels }}
         with:
           script: |
-            const { Build } = require('@docker/actions-toolkit/lib/buildx/build');
-            const { GitHub } = require('@docker/actions-toolkit/lib/github/github');
-            const { Util } = require('@docker/actions-toolkit/lib/util');
+            const { Build } = require('@docker/github-builder-runtime/lib/buildx/build');
+            const { GitHub } = require('@docker/github-builder-runtime/lib/github/github');
+            const { Util } = require('@docker/github-builder-runtime/lib/util');
             
             const inpPlatform = core.getInput('platform');
             const platformPairSuffix = inpPlatform ? `-${inpPlatform.replace(/\//g, '-')}` : '';
@@ -823,7 +818,7 @@ jobs:
           INPUT_IMAGE-DIGEST: ${{ steps.build.outputs.digest }}
         with:
           script: |
-            const { Sigstore } = require('@docker/actions-toolkit/lib/sigstore/sigstore');
+            const { Sigstore } = require('@docker/github-builder-runtime/lib/sigstore/sigstore');
             
             const inpImageNames = core.getMultilineInput('image-names');
             const inpImageDigest = core.getInput('image-digest');
@@ -859,7 +854,7 @@ jobs:
         with:
           script: |
             const path = require('path');
-            const { Sigstore } = require('@docker/actions-toolkit/lib/sigstore/sigstore');
+            const { Sigstore } = require('@docker/github-builder-runtime/lib/sigstore/sigstore');
             const inplocalExportDir = core.getInput('local-output-dir');
             
             const sigstore = new Sigstore();
@@ -941,10 +936,10 @@ jobs:
         name: Install dependencies
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_DAT-MODULE: ${{ env.DOCKER_ACTIONS_TOOLKIT_MODULE }}
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--prefer-offline', '--ignore-scripts', core.getInput('dat-module')]);
+            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
       -
         name: Docker meta
         id: meta
@@ -988,7 +983,7 @@ jobs:
           INPUT_META-ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
         with:
           script: |
-            const { ImageTools } = require('@docker/actions-toolkit/lib/buildx/imagetools');
+            const { ImageTools } = require('@docker/github-builder-runtime/lib/buildx/imagetools');
             
             const inpPush = core.getBooleanInput('push');
             const inpImageNames = core.getMultilineInput('image-names');

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,15 @@ env:
   SBOM_IMAGE: "docker/buildkit-syft-scanner:1.11.0"
   BINFMT_IMAGE: "tonistiigi/binfmt:qemu-v10.2.1-65"
   RUNTIME_MODULE: "@docker/github-builder-runtime@0.91.0"
+  RUNTIME_INSTALL_ARGS: |
+    --loglevel=error
+    --no-save
+    --package-lock=false
+    --ignore-scripts
+    --omit=dev
+    --prefer-offline
+    --fund=false
+    --audit=false
   COSIGN_VERSION: "v3.0.6"
   LOCAL_EXPORT_DIR: "/tmp/buildx-output"
   MATRIX_SIZE_LIMIT: "20"
@@ -186,9 +195,24 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
       -
         name: Install Cosign
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -485,9 +509,24 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
       -
         name: Docker meta
         id: meta
@@ -937,9 +976,24 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
       -
         name: Docker meta
         id: meta

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,16 @@ on:
 
 env:
   RUNTIME_MODULE: "@docker/github-builder-runtime@0.91.0"
+  RUNTIME_INSTALL_ARGS: |
+    --loglevel=error
+    --no-save
+    --package-lock=false
+    --ignore-scripts
+    --omit=dev
+    --prefer-offline
+    --fund=false
+    --audit=false
+  NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
   verify:
@@ -53,9 +63,24 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
       -
         name: Install Cosign
         if: ${{ steps.vars.outputs.signed == 'true' }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ on:
         required: false
 
 env:
-  RUNTIME_MODULE: "@docker/github-builder-runtime@0.90.0"
+  RUNTIME_MODULE: "@docker/github-builder-runtime@0.91.0"
 
 jobs:
   verify:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ on:
         required: false
 
 env:
-  DOCKER_ACTIONS_TOOLKIT_MODULE: "@docker/actions-toolkit@0.90.0"
+  RUNTIME_MODULE: "@docker/github-builder-runtime@0.90.0"
 
 jobs:
   verify:
@@ -48,14 +48,14 @@ jobs:
             core.setOutput('output-type', outputType);
             core.setOutput('signed', signed);
       -
-        name: Install @docker/actions-toolkit
+        name: Install @docker/github-builder-runtime
         if: ${{ steps.vars.outputs.signed == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_DAT-MODULE: ${{ env.DOCKER_ACTIONS_TOOLKIT_MODULE }}
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
         with:
           script: |
-            await exec.exec('npm', ['install', '--prefer-offline', '--ignore-scripts', core.getInput('dat-module')]);
+            await exec.exec('npm', ['install', '--loglevel=error', '--no-save', '--package-lock=false', '--ignore-scripts', '--omit=dev', '--prefer-offline', '--fund=false', '--audit=false', core.getInput('runtime-module')]);
       -
         name: Install Cosign
         if: ${{ steps.vars.outputs.signed == 'true' }}
@@ -64,8 +64,8 @@ jobs:
           INPUT_COSIGN-VERSION: ${{ steps.vars.outputs.cosign-version }}
         with:
           script: |
-            const { Cosign } = require('@docker/actions-toolkit/lib/cosign/cosign');
-            const { Install } = require('@docker/actions-toolkit/lib/cosign/install');
+            const { Cosign } = require('@docker/github-builder-runtime/lib/cosign/cosign');
+            const { Install } = require('@docker/github-builder-runtime/lib/cosign/install');
 
             const cosignInstall = new Install();
             const cosignBinPath = await cosignInstall.download({


### PR DESCRIPTION
follow-up https://github.com/docker/actions-toolkit/pull/1145

This switches the reusable workflows from `@docker/actions-toolkit` to the new `@docker/github-builder-runtime` package.

The workflows now install `@docker/github-builder-runtime@0.91.0` through `RUNTIME_MODULE`, use the runtime package import paths, and keep the hardened npm install flags. The dependency updater now resolves future runtime package updates from npm.

This consumes the shrinkwrapped runtime package introduced by https://github.com/docker/actions-toolkit/pull/1145 and narrows the installed dependency surface used by GitHub Builder workflows.