### PR TITLE
feat(workflows): replace AWS_ACCESS_KEY_ID secrets with OIDC role assumption

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -45,24 +45,25 @@ jobs:
         public.ecr.aws/q3b5f1u4/test-docker-action
       meta-tags: |
         type=raw,value=bake-ghbuilder-single-${{ github.run_id }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-aws-single-verify:
     uses: ./.github/workflows/verify.yml
     if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - bake-aws-single
     with:
       builder-outputs: ${{ toJSON(needs.bake-aws-single.outputs) }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-aws-single-outputs:
     runs-on: ubuntu-24.04
@@ -102,24 +103,25 @@ jobs:
         public.ecr.aws/q3b5f1u4/test-docker-action
       meta-tags: |
         type=raw,value=bake-ghbuilder-${{ github.run_id }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-aws-verify:
     uses: ./.github/workflows/verify.yml
     if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - bake-aws
     with:
       builder-outputs: ${{ toJSON(needs.bake-aws.outputs) }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-aws-outputs:
     runs-on: ubuntu-24.04
@@ -141,14 +143,22 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     needs:
       - bake-aws
+    permissions:
+      contents: read
+      id-token: write
     steps:
+      -
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
+          aws-region: us-east-1
+          role-session-name: gha-github-builder-scan-${{ github.run_id }}-${{ github.run_attempt }}
       -
         name: Login to registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       -
         name: Scan for vulnerabilities
         uses: crazy-max/ghaction-container-scan@a0a3900b79d158c85ccf034e5368fae620a9233a # v4.0.0
@@ -175,24 +185,25 @@ jobs:
         public.ecr.aws/q3b5f1u4/test-docker-action
       meta-tags: |
         type=raw,value=bake-ghbuilder-nosign-${{ github.run_id }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-aws-nosign-verify:
     uses: ./.github/workflows/verify.yml
     if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - bake-aws-nosign
     with:
       builder-outputs: ${{ toJSON(needs.bake-aws-nosign.outputs) }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-aws-nosign-outputs:
     runs-on: ubuntu-24.04
@@ -279,30 +290,31 @@ jobs:
         public.ecr.aws/q3b5f1u4/test-docker-action
       meta-tags: |
         type=raw,value=${{ github.run_id }},prefix=bake-ghcr-and-aws-
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-ghcr-and-aws-verify:
     uses: ./.github/workflows/verify.yml
     if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - bake-ghcr-and-aws
     with:
       builder-outputs: ${{ toJSON(needs.bake-ghcr-and-aws.outputs) }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-ghcr-and-aws-outputs:
     runs-on: ubuntu-24.04
@@ -532,11 +544,10 @@ jobs:
         public.ecr.aws/q3b5f1u4/test-docker-action
       meta-tags: |
         type=raw,value=bake-ghbuilder-nodistrib-${{ github.run_id }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       registry-auths: |
         - registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   bake-local-nodistrib:
     uses: ./.github/workflows/bake.yml

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -126,6 +126,15 @@ on:
         type: string
         description: "Bake target name for metadata (defaults to docker-metadata-action)"
         required: false
+      aws-role-to-assume:
+        type: string
+        description: "IAM role ARN to assume via OIDC for ECR/ECR Public authentication. When set, configure-aws-credentials runs before registry login."
+        required: false
+      aws-region:
+        type: string
+        description: "AWS region for configure-aws-credentials (defaults to us-east-1 for ECR Public)"
+        required: false
+        default: us-east-1
     secrets:
       registry-auths:
         description: "Raw authentication to registries, defined as YAML objects (for image output)"
@@ -953,6 +962,14 @@ jobs:
               core.setOutput('overrides', bakeOverrides.join(os.EOL));
             });
       -
+        name: Configure AWS credentials
+        if: ${{ inputs.aws-role-to-assume != '' }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          aws-region: ${{ inputs.aws-region }}
+          role-session-name: gha-github-builder-${{ github.run_id }}-${{ github.run_attempt }}
+      -
         name: Login to registry
         if: ${{ inputs.push && inputs.output == 'image' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -1151,6 +1168,14 @@ jobs:
           labels: ${{ inputs.meta-labels }}
           annotations: ${{ inputs.meta-annotations }}
           bake-target: ${{ inputs.meta-bake-target }}
+      -
+        name: Configure AWS credentials
+        if: ${{ inputs.aws-role-to-assume != '' }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          aws-region: ${{ inputs.aws-region }}
+          role-session-name: gha-github-builder-${{ github.run_id }}-${{ github.run_attempt }}
       -
         name: Login to registry
         if: ${{ inputs.push && inputs.output == 'image' }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,6 +7,15 @@ on:
         type: string
         description: "JSON build outputs from Docker GitHub Builder reusable workflows"
         required: true
+      aws-role-to-assume:
+        type: string
+        description: "IAM role ARN to assume via OIDC for ECR/ECR Public authentication during signing verification"
+        required: false
+      aws-region:
+        type: string
+        description: "AWS region for configure-aws-credentials (defaults to us-east-1 for ECR Public)"
+        required: false
+        default: us-east-1
     secrets:
       registry-auths:
         description: "Registry authentication details as YAML objects"
@@ -103,6 +112,14 @@ jobs:
 
             const cosign = new Cosign();
             await cosign.printVersion();
+      -
+        name: Configure AWS credentials
+        if: ${{ inputs.aws-role-to-assume != '' && steps.vars.outputs.signed == 'true' && steps.vars.outputs.output-type == 'image' }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          aws-region: ${{ inputs.aws-region }}
+          role-session-name: gha-github-builder-verify-${{ github.run_id }}-${{ github.run_attempt }}
       -
         name: Login to registry
         if: ${{ steps.vars.outputs.signed == 'true' && steps.vars.outputs.output-type == 'image' }}


### PR DESCRIPTION
## Summary

Replaces static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` repository secrets with GitHub Actions OIDC role assumption for all ECR/ECR Public operations.

**Changes:**
- `bake.yml`: adds `aws-role-to-assume` + `aws-region` inputs; adds `configure-aws-credentials` step (pinned SHA, `role-session-name`) before ECR login in both `build` and `finalize` jobs
- `verify.yml`: same inputs + `configure-aws-credentials` step gated on `signed==true && output-type==image`
- `.test-bake.yml`: all `bake-aws-*` jobs pass `aws-role-to-assume` via `with:` and drop username/password from `registry-auths`; `bake-aws-scan` job gets inline `configure-aws-credentials`; all verify jobs that use ECR get `id-token: write`

**Mechanism:** `docker/login-action` falls back to the AWS SDK credential chain when no `username`/`password` are provided — the ambient `AWS_ACCESS_KEY_ID`/`AWS_SESSION_TOKEN` set by `configure-aws-credentials` are picked up automatically.

## IAM role

`arn:aws:iam::175142243308:role/official_gha_cicd` — created by `docker/infra-terraform` PR #12395.

## `configure-aws-credentials` action

Pinned: `aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a` (v4.3.1)

## ⚠️ Blocked on

1. `docker/infra-terraform-modules` PR #2931 merged and `official_gha_cicd_v1.1.0` tagged
2. `docker/infra-terraform` PR #12395 applied to sandbox account

## After this merges

Delete the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` repository secrets — they are no longer used.

## Test plan

- [ ] Merge and apply Terraform PRs first (#2931, #12395)
- [ ] Push to a feature branch — verify `Configure AWS credentials` step runs and ECR login succeeds
- [ ] Verify that PR builds (push=false) do not fail due to missing ECR credentials
- [ ] Confirm signing verification jobs (`bake-aws-single-verify`, etc.) complete successfully on push

> *PR drafted by Claude Code.*