### PR TITLE
add registry-login input for optional registry auth before build

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -726,3 +726,25 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  bake-local-login:
+    uses: ./.github/workflows/bake.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-name: bake-login-output
+      artifact-upload: true
+      context: test
+      output: local
+      registry-login: true
+      sbom: true
+      sign: true
+      target: dhi
+    secrets:
+      registry-auths: |
+        - registry: dhi.io
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
+          scope: 'dhi.io@pull'

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -745,3 +745,24 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  build-local-login:
+    uses: ./.github/workflows/build.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      artifact-name: build-login-output
+      artifact-upload: true
+      file: test/dhi.Dockerfile
+      output: local
+      registry-login: true
+      sbom: true
+      sign: true
+    secrets:
+      registry-auths: |
+        - registry: dhi.io
+          username: ${{ vars.DOCKERPUBLICBOT_USERNAME }}
+          password: ${{ secrets.DOCKERPUBLICBOT_READ_PAT }}
+          scope: 'dhi.io@pull'

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -77,6 +77,11 @@ on:
         description: "Push image to the registry (for image output)"
         required: false
         default: false
+      registry-login:
+        type: string
+        description: "Login to registry before build (one of auto, true or false). Auto enables login only when output is image and push is true"
+        required: false
+        default: auto
       sbom:
         type: boolean
         description: "Generate SBOM attestation for the build"
@@ -141,7 +146,7 @@ on:
         required: false
     secrets:
       registry-auths:
-        description: "Raw authentication to registries, defined as YAML objects (for image output)"
+        description: "Raw authentication to registries, defined as YAML objects"
         required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
@@ -195,7 +200,7 @@ jobs:
   registry-identities:
     uses: ./.github/workflows/setup-registry-identities.yml
     with:
-      registry-login: ${{ inputs.push && inputs.output == 'image' }}
+      registry-login: ${{ inputs.registry-login == 'true' || (inputs.registry-login == 'auto' && inputs.push && inputs.output == 'image') }}
       registry-identities: ${{ inputs.registry-identities }}
 
   prepare:
@@ -209,6 +214,7 @@ jobs:
       metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
+      registryLogin: ${{ steps.set.outputs.registryLogin }}
     steps:
       -
         name: Install dependencies
@@ -308,6 +314,7 @@ jobs:
           INPUT_FILES: ${{ inputs.files }}
           INPUT_OUTPUT: ${{ inputs.output }}
           INPUT_PUSH: ${{ inputs.push }}
+          INPUT_REGISTRY-LOGIN: ${{ inputs.registry-login }}
           INPUT_SBOM: ${{ inputs.sbom }}
           INPUT_SET: ${{ inputs.set }}
           INPUT_SIGN: ${{ inputs.sign }}
@@ -336,6 +343,7 @@ jobs:
             const inpFiles = Util.getInputList('files');
             const inpOutput = core.getInput('output');
             const inpPush = core.getBooleanInput('push');
+            const inpRegistryLogin = core.getInput('registry-login');
             const inpSbom = core.getBooleanInput('sbom');
             const inpSet = Util.getInputList('set', {ignoreComma: true, quote: false});
             const inpSign = core.getInput('sign');
@@ -465,7 +473,13 @@ jobs:
             await core.group(`Set bake source`, async () => {
               core.info(bakeSource);
             });
-            
+
+            if (!['auto', 'true', 'false'].includes(inpRegistryLogin)) {
+              core.setFailed(`Invalid registry-login input: ${inpRegistryLogin}`);
+              return;
+            }
+            const registryLogin = inpRegistryLogin === 'auto' ? inpOutput === 'image' && inpPush : inpRegistryLogin === 'true';
+
             const envs = Object.assign({},
               inpVars ? inpVars.reduce((acc, curr) => {
                 const idx = curr.indexOf('=');
@@ -551,7 +565,7 @@ jobs:
               core.setFailed(error);
               return;
             }
-            
+
             const platforms = def.target[target].platforms || [];
             if (inpDistribute && platforms.length > inpMatrixSizeLimit) {
               core.setFailed(`Platforms to build exceed matrix size limit of ${inpMatrixSizeLimit}`);
@@ -597,6 +611,10 @@ jobs:
               const ghaCacheSign = actionsIdTokenSet ? 'true' : 'false';
               core.info(`ghaCacheSign: ${ghaCacheSign}`);
               core.setOutput('ghaCacheSign', ghaCacheSign);
+            });
+            await core.group(`Set registryLogin output`, async () => {
+              core.info(`registryLogin: ${registryLogin}`);
+              core.setOutput('registryLogin', registryLogin);
             });
 
   build:
@@ -1034,7 +1052,7 @@ jobs:
               username: ${{ needs.registry-identities.outputs.dockerhub-oidc-username }}
       -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
+        if: ${{ needs.prepare.outputs.registryLogin == 'true' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,11 @@ on:
         description: "Push image to the registry (for image output)"
         required: false
         default: false
+      registry-login:
+        type: string
+        description: "Login to registry before build (one of auto, true or false). Auto enables login only when output is image and push is true"
+        required: false
+        default: auto
       sbom:
         type: boolean
         description: "Generate SBOM attestation for the build"
@@ -152,7 +157,7 @@ on:
         required: false
     secrets:
       registry-auths:
-        description: "Raw authentication to registries, defined as YAML objects (for image output)"
+        description: "Raw authentication to registries, defined as YAML objects"
         required: false
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
@@ -206,7 +211,7 @@ jobs:
   registry-identities:
     uses: ./.github/workflows/setup-registry-identities.yml
     with:
-      registry-login: ${{ inputs.push && inputs.output == 'image' }}
+      registry-login: ${{ inputs.registry-login == 'true' || (inputs.registry-login == 'auto' && inputs.push && inputs.output == 'image') }}
       registry-identities: ${{ inputs.registry-identities }}
 
   prepare:
@@ -221,6 +226,7 @@ jobs:
       sign: ${{ steps.set.outputs.sign }}
       privateRepo: ${{ steps.set.outputs.privateRepo }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
+      registryLogin: ${{ steps.set.outputs.registryLogin }}
     steps:
       -
         name: Install dependencies
@@ -310,6 +316,7 @@ jobs:
           INPUT_OUTPUT: ${{ inputs.output }}
           INPUT_PLATFORMS: ${{ inputs.platforms }}
           INPUT_PUSH: ${{ inputs.push }}
+          INPUT_REGISTRY-LOGIN: ${{ inputs.registry-login }}
           INPUT_SIGN: ${{ inputs.sign }}
         with:
           script: |
@@ -327,6 +334,7 @@ jobs:
             const inpPlatforms = Util.getInputList('platforms');
             const inpOutput = core.getInput('output');
             const inpPush = core.getBooleanInput('push');
+            const inpRegistryLogin = core.getInput('registry-login');
             const inpSign = core.getInput('sign');
             
             const parseRunnerConfig = value => {
@@ -446,7 +454,13 @@ jobs:
               core.setFailed(`signing attestation manifests requires push to be enabled`);
               return;
             }
-            
+
+            if (!['auto', 'true', 'false'].includes(inpRegistryLogin)) {
+              core.setFailed(`Invalid registry-login input: ${inpRegistryLogin}`);
+              return;
+            }
+            const registryLogin = inpRegistryLogin === 'auto' ? inpOutput === 'image' && inpPush : inpRegistryLogin === 'true';
+
             if (inpDistribute && inpPlatforms.length > inpMatrixSizeLimit) {
               core.setFailed(`Platforms to build exceed matrix size limit of ${inpMatrixSizeLimit}`);
               return;
@@ -497,6 +511,10 @@ jobs:
               const ghaCacheSign = actionsIdTokenSet ? 'true' : 'false';
               core.info(`ghaCacheSign: ${ghaCacheSign}`);
               core.setOutput('ghaCacheSign', ghaCacheSign);
+            });
+            await core.group(`Set registryLogin output`, async () => {
+              core.info(`registryLogin: ${registryLogin}`);
+              core.setOutput('registryLogin', registryLogin);
             });
 
   build:
@@ -900,7 +918,7 @@ jobs:
               username: ${{ needs.registry-identities.outputs.dockerhub-oidc-username }}
       -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
+        if: ${{ needs.prepare.outputs.registryLogin == 'true' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ ___
     * [AWS ECR](#aws-ecr)
     * [Google Artifact Registry](#google-artifact-registry)
   * [Runner mapping](#runner-mapping)
+  * [Registry login](#registry-login)
   * [Metadata templates](#metadata-templates)
 
 ## Overview
@@ -240,6 +241,7 @@ jobs:
 | `platforms`               | List/CSV |                                       | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) to build                                                                                                                                                                                               |
 | `push`                    | Bool     | `false`                               | [Push](https://docs.docker.com/engine/reference/commandline/buildx_build/#push) image to the registry (for `image` output)                                                                                                                                                                                     |
 | `registry-identities`     | YAML     |                                       | Keyless registry identity configuration. See [Registry identities](#registry-identities).                                                                                                                                                                                                                      |
+| `registry-login`          | String   | `auto`                                | [Login to registry](#registry-login) before build (one of `auto`, `true` or `false`)                                                                                                                                                                                                                           |
 | `sbom`                    | Bool     | `false`                               | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                                    |
 | `shm-size`                | String   |                                       | Size of [`/dev/shm`](https://docs.docker.com/engine/reference/commandline/buildx_build/#shm-size) (e.g., `2g`)                                                                                                                                                                                                 |
 | `sign`                    | String   | `auto`                                | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact           |
@@ -255,10 +257,10 @@ jobs:
 
 ### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| Name             | Default               | Description                                                              |
+|------------------|-----------------------|--------------------------------------------------------------------------|
+| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects                |
+| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context |
 
 ### Outputs
 
@@ -352,6 +354,7 @@ jobs:
 | `output`                  | String |                                       | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/)).                                                                                                                               |
 | `push`                    | Bool   | `false`                               | Push image to the registry (for `image` output)                                                                                                                                                                                                                                                      |
 | `registry-identities`     | YAML   |                                       | Keyless registry identity configuration. See [Registry identities](#registry-identities).                                                                                                                                                                                                            |
+| `registry-login`          | String | `auto`                                | [Login to registry](#registry-login) before build (one of `auto`, `true` or `false`)                                                                                                                                                                                                                 |
 | `sbom`                    | Bool   | `false`                               | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                          |
 | `set`                     | List   |                                       | List of [target values to override](https://docs.docker.com/engine/reference/commandline/buildx_bake/#set) (e.g., `targetpattern.key=value`)                                                                                                                                                         |
 | `sign`                    | String | `auto`                                | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact |
@@ -367,10 +370,10 @@ jobs:
 
 ### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| Name             | Default               | Description                                                              |
+|------------------|-----------------------|--------------------------------------------------------------------------|
+| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects                |
+| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context |
 
 ### Outputs
 
@@ -564,6 +567,21 @@ runner: |
 
 For example, `linux` matches all Linux platforms, `linux/arm` matches variants
 such as `linux/arm/v7`, and `linux/arm64` is separate from `linux/arm`.
+
+### Registry login
+
+The `registry-login` input controls whether the workflows run a registry login
+before the build step. `auto` preserves the existing behavior and enables login
+only when `output=image` and `push=true`.
+
+When `registry-login=true`, the workflow always attempts pre-build login. If
+credentials resolve to empty values, for example on forked pull requests where
+secrets are not exposed, login fails. Gate the input at the caller side for
+fork-safe workflows:
+
+```yaml
+registry-login: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+```
 
 ### Metadata templates
 

--- a/test/dhi.Dockerfile
+++ b/test/dhi.Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+
+FROM dhi.io/alpine-base:3.23 AS base
+ARG TARGETPLATFORM
+RUN echo "Hello, World! This is ${TARGETPLATFORM}" > /tmp/hello.txt
+ARG BUILDKIT_SBOM_SCAN_STAGE=true
+
+FROM scratch
+COPY --from=base /tmp/hello.txt /

--- a/test/docker-bake.hcl
+++ b/test/docker-bake.hcl
@@ -67,3 +67,8 @@ target "generated-hello2" {
   dockerfile = "hello.Dockerfile"
   output = ["type=cacheonly"]
 }
+
+target "dhi" {
+  inherits = ["docker-metadata-action"]
+  dockerfile = "dhi.Dockerfile"
+}


### PR DESCRIPTION
carry #117 with a fork

* fixes https://github.com/docker/github-builder/issues/97
* fixes https://github.com/docker/github-builder/issues/116

This PR adds a `registry-login` input to both reusable workflows to control whether registry login happens before the build step. The input supports `auto`, `true`, and `false`:

- `auto` preserves the current behavior and enables login only when `output=image` and `push=true`
- `true` always attempts a pre-build login
- `false` disables pre-build login

This makes pre-build registry authentication available for cases such as local output or non-push builds, while keeping the default behavior unchanged.