### PR TITLE
build: pass secrets to docker-build-push action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,15 @@ on:
       github-token:
         description: "GitHub Token used to authenticate against the repository for Git context"
         required: false
+      build-secrets:
+        description: List of secrets to expose to the build (e.g., key=string, SSH_AUTH_KEY=mykey)
+        required: false
+      build-secret-envs:
+        description: List of secret env vars to expose to the build (e.g., key=envname, MY_SECRET=MY_ENV_VAR)
+        required: false
+      build-secret-files:
+        description: List of secret files to expose to the build (e.g., key=filename, MY_SECRET=./secret.txt)
+        required: false
     outputs:
       meta-json:
         description: "Metadata JSON output (for image output)"
@@ -833,7 +842,11 @@ jobs:
           platforms: ${{ steps.prepare.outputs.platform }}
           provenance: ${{ steps.prepare.outputs.provenance }}
           sbom: ${{ steps.prepare.outputs.sbom }}
-          secret-envs: GIT_AUTH_TOKEN=GIT_AUTH_TOKEN
+          secrets: ${{ secrets.build-secrets }}
+          secret-envs: |
+            GIT_AUTH_TOKEN=GIT_AUTH_TOKEN
+            ${{ secrets.build-secret-envs }}
+          secret-files: ${{ secrets.build-secret-files }}
           shm-size: ${{ inputs.shm-size }}
           target: ${{ inputs.target }}
           ulimit: ${{ inputs.ulimit }}

--- a/README.md
+++ b/README.md
@@ -246,10 +246,13 @@ jobs:
 
 ### Secrets
 
-| Name             | Default               | Description                                                                    |
-|------------------|-----------------------|--------------------------------------------------------------------------------|
-| `registry-auths` |                       | Raw authentication to registries, defined as YAML objects (for `image` output) |
-| `github-token`   | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context       |
+| Name                 | Default               | Description                                                                                                                                              |
+|----------------------|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `registry-auths`     |                       | Raw authentication to registries, defined as YAML objects (for `image` output)                                                                           |
+| `github-token`       | `${{ github.token }}` | GitHub Token used to authenticate against the repository for Git context                                                                                 |
+| `build-secrets`      | List                  | List of [secrets](https://docs.docker.com/build/ci/github-actions/secrets/) to expose to the build (e.g., `key=string`, `SSH_AUTH_KEY=mykey`)            |
+| `build-secret-envs`  | List/CSV              | List of [secret env vars](https://docs.docker.com/build/ci/github-actions/secrets/) to expose to the build (e.g., `key=envname`, `MY_SECRET=MY_ENV_VAR`) |
+| `build-secret-files` | List                  | List of [secret files](https://docs.docker.com/build/ci/github-actions/secrets/) to expose to the build (e.g., `key=filename`, `MY_SECRET=./secret.txt`) |
 
 ### Outputs
 


### PR DESCRIPTION
I have some docker builds which use [build secrets](https://docs.docker.com/build/building/secrets/). With the docker [build-push-action](https://github.com/docker/build-push-action) I can supply these secrets as an input to the action, but that input is not exposed with the workflow here. This PR simply exposes those options as secret inputs to the workflow and passes them down to the build-push-action.