### PR TITLE
build/bake: registry identities support

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -16,12 +16,14 @@ on:
     paths:
       - '.github/workflows/.test-bake.yml'
       - '.github/workflows/bake.yml'
+      - '.github/workflows/setup-registry-identities.yml'
       - '.github/workflows/verify.yml'
       - 'test/**'
   pull_request:
     paths:
       - '.github/workflows/.test-bake.yml'
       - '.github/workflows/bake.yml'
+      - '.github/workflows/setup-registry-identities.yml'
       - '.github/workflows/verify.yml'
       - 'test/**'
 
@@ -79,6 +81,54 @@ jobs:
           script: |
             const builderOutputs = JSON.parse(core.getInput('builder-outputs'));
             core.info(JSON.stringify(builderOutputs, null, 2));
+
+  bake-ecr-public:
+    uses: ./.github/workflows/bake.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      context: test
+      output: image
+      push: true
+      sbom: true
+      set: |
+        *.args.VERSION={{meta.version}}
+      target: hello
+      registry-identities: |
+        - type: aws-ecr
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
+          registry: public.ecr.aws
+      meta-images: |
+        public.ecr.aws/q3b5f1u4/test-docker-action
+      meta-tags: |
+        type=raw,value=bake-ecr-public-${{ github.run_id }}
+
+  bake-ecr-private:
+    uses: ./.github/workflows/bake.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      context: test
+      output: image
+      push: true
+      sbom: true
+      set: |
+        *.args.VERSION={{meta.version}}
+      target: hello
+      registry-identities: |
+        - type: aws-ecr
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
+          registry: 175142243308.dkr.ecr.us-east-2.amazonaws.com
+      meta-images: |
+        175142243308.dkr.ecr.us-east-2.amazonaws.com/sandbox/test-docker-action
+      meta-tags: |
+        type=raw,value=bake-ecr-private-${{ github.run_id }}
 
   bake-dockerhub:
     uses: ./.github/workflows/bake.yml

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -16,12 +16,14 @@ on:
     paths:
       - '.github/workflows/.test-build.yml'
       - '.github/workflows/build.yml'
+      - '.github/workflows/setup-registry-identities.yml'
       - '.github/workflows/verify.yml'
       - 'test/**'
   pull_request:
     paths:
       - '.github/workflows/.test-build.yml'
       - '.github/workflows/build.yml'
+      - '.github/workflows/setup-registry-identities.yml'
       - '.github/workflows/verify.yml'
       - 'test/**'
 
@@ -78,6 +80,52 @@ jobs:
           script: |
             const builderOutputs = JSON.parse(core.getInput('builder-outputs'));
             core.info(JSON.stringify(builderOutputs, null, 2));
+
+  build-ecr-public:
+    uses: ./.github/workflows/build.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      build-args: |
+        VERSION={{meta.version}}
+      file: test/hello.Dockerfile
+      output: image
+      push: true
+      sbom: true
+      registry-identities: |
+        - type: aws-ecr
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
+          registry: public.ecr.aws
+      meta-images: |
+        public.ecr.aws/q3b5f1u4/test-docker-action
+      meta-tags: |
+        type=raw,value=build-ecr-public-${{ github.run_id }}
+
+  build-ecr-private:
+    uses: ./.github/workflows/build.yml
+    if: ${{ github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      build-args: |
+        VERSION={{meta.version}}
+      file: test/hello.Dockerfile
+      output: image
+      push: true
+      sbom: true
+      registry-identities: |
+        - type: aws-ecr
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
+          registry: 175142243308.dkr.ecr.us-east-2.amazonaws.com
+      meta-images: |
+        175142243308.dkr.ecr.us-east-2.amazonaws.com/sandbox/test-docker-action
+      meta-tags: |
+        type=raw,value=build-ecr-private-${{ github.run_id }}
 
   build-dockerhub:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/.update-deps.yml
+++ b/.github/workflows/.update-deps.yml
@@ -168,6 +168,7 @@ jobs:
                 files: [
                   '.github/workflows/build.yml',
                   '.github/workflows/bake.yml',
+                  '.github/workflows/setup-registry-identities.yml',
                   '.github/workflows/verify.yml'
                 ],
                 sourceUrl: 'https://www.npmjs.com/package/@docker/github-builder-runtime',

--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -100,6 +100,10 @@ on:
         type: string
         description: "Variables to set in the Bake definition as list of key-value pair"
         required: false
+      registry-identities:
+        type: string
+        description: "Keyless registry identity configuration as YAML objects"
+        required: false
       # docker/metadata-action
       set-meta-annotations:
         type: boolean
@@ -188,6 +192,11 @@ env:
   NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
+  registry-identities:
+    uses: ./.github/workflows/setup-registry-identities.yml
+    with:
+      registry-identities: ${{ inputs.registry-identities }}
+
   prepare:
     runs-on: ubuntu-24.04
     strategy:
@@ -592,7 +601,10 @@ jobs:
   build:
     runs-on: ${{ matrix.runner }}
     needs:
+      - registry-identities
       - prepare
+    env:
+      REGISTRY_AUTHS_PRESENT: ${{ secrets.registry-auths != '' }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
@@ -975,8 +987,21 @@ jobs:
               core.setOutput('overrides', bakeOverrides.join(os.EOL));
             });
       -
+        name: Configure AWS credentials
+        if: ${{ needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
+        with:
+          role-to-assume: ${{ needs.registry-identities.outputs.aws-ecr-role-to-assume }}
+          aws-region: ${{ needs.registry-identities.outputs.aws-ecr-region }}
+      -
+        name: Login to Amazon ECR
+        if: ${{ needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry-auth: ${{ needs.registry-identities.outputs.aws-ecr-registry-auth }}
+      -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ inputs.push && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry-auth: ${{ secrets.registry-auths }}
@@ -1008,7 +1033,7 @@ jobs:
             core.setOutput('digest', imageDigest);
       -
         name: Login to registry for signing
-        if: ${{ needs.prepare.outputs.sign == 'true' && inputs.output == 'image' }}
+        if: ${{ needs.prepare.outputs.sign == 'true' && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry-auth: ${{ secrets.registry-auths }}
@@ -1140,8 +1165,11 @@ jobs:
       output-type: ${{ inputs.output }}
       signed: ${{ needs.prepare.outputs.sign }}
     needs:
+      - registry-identities
       - prepare
       - build
+    env:
+      REGISTRY_AUTHS_PRESENT: ${{ secrets.registry-auths != '' }}
     steps:
       -
         name: Install dependencies
@@ -1179,8 +1207,21 @@ jobs:
           annotations: ${{ inputs.meta-annotations }}
           bake-target: ${{ inputs.meta-bake-target }}
       -
+        name: Configure AWS credentials
+        if: ${{ inputs.push && inputs.output == 'image' && needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
+        with:
+          role-to-assume: ${{ needs.registry-identities.outputs.aws-ecr-role-to-assume }}
+          aws-region: ${{ needs.registry-identities.outputs.aws-ecr-region }}
+      -
+        name: Login to Amazon ECR
+        if: ${{ inputs.push && inputs.output == 'image' && needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry-auth: ${{ needs.registry-identities.outputs.aws-ecr-registry-auth }}
+      -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ inputs.push && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,10 @@ on:
         type: string
         description: "Ulimit options (e.g., nofile=1024:1024)"
         required: false
+      registry-identities:
+        type: string
+        description: "Keyless registry identity configuration as YAML objects"
+        required: false
       # docker/metadata-action
       set-meta-annotations:
         type: boolean
@@ -191,6 +195,11 @@ env:
   NPM_CONFIG_FETCH_RETRIES: "5"
 
 jobs:
+  registry-identities:
+    uses: ./.github/workflows/setup-registry-identities.yml
+    with:
+      registry-identities: ${{ inputs.registry-identities }}
+
   prepare:
     runs-on: ubuntu-24.04
     strategy:
@@ -484,7 +493,10 @@ jobs:
   build:
     runs-on: ${{ matrix.runner }}
     needs:
+      - registry-identities
       - prepare
+    env:
+      REGISTRY_AUTHS_PRESENT: ${{ secrets.registry-auths != '' }}
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
@@ -833,8 +845,21 @@ jobs:
               core.setOutput('provenance', Build.resolveProvenanceAttrs(`mode=max,version=v1`));
             }
       -
+        name: Configure AWS credentials
+        if: ${{ needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
+        with:
+          role-to-assume: ${{ needs.registry-identities.outputs.aws-ecr-role-to-assume }}
+          aws-region: ${{ needs.registry-identities.outputs.aws-ecr-region }}
+      -
+        name: Login to Amazon ECR
+        if: ${{ needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry-auth: ${{ needs.registry-identities.outputs.aws-ecr-registry-auth }}
+      -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ inputs.push && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry-auth: ${{ secrets.registry-auths }}
@@ -863,7 +888,7 @@ jobs:
           GIT_AUTH_TOKEN: ${{ secrets.github-token || github.token }}
       -
         name: Login to registry for signing
-        if: ${{ needs.prepare.outputs.sign == 'true' && inputs.output == 'image' }}
+        if: ${{ needs.prepare.outputs.sign == 'true' && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry-auth: ${{ secrets.registry-auths }}
@@ -995,8 +1020,11 @@ jobs:
       output-type: ${{ inputs.output }}
       signed: ${{ needs.prepare.outputs.sign }}
     needs:
+      - registry-identities
       - prepare
       - build
+    env:
+      REGISTRY_AUTHS_PRESENT: ${{ secrets.registry-auths != '' }}
     steps:
       -
         name: Install dependencies
@@ -1033,8 +1061,21 @@ jobs:
           labels: ${{ inputs.meta-labels }}
           annotations: ${{ inputs.meta-annotations }}
       -
+        name: Configure AWS credentials
+        if: ${{ inputs.push && inputs.output == 'image' && needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59 # v6.1.3
+        with:
+          role-to-assume: ${{ needs.registry-identities.outputs.aws-ecr-role-to-assume }}
+          aws-region: ${{ needs.registry-identities.outputs.aws-ecr-region }}
+      -
+        name: Login to Amazon ECR
+        if: ${{ inputs.push && inputs.output == 'image' && needs.registry-identities.outputs.aws-ecr-enabled == 'true' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry-auth: ${{ needs.registry-identities.outputs.aws-ecr-registry-auth }}
+      -
         name: Login to registry
-        if: ${{ inputs.push && inputs.output == 'image' }}
+        if: ${{ inputs.push && inputs.output == 'image' && env.REGISTRY_AUTHS_PRESENT == 'true' }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry-auth: ${{ secrets.registry-auths }}

--- a/.github/workflows/setup-registry-identities.yml
+++ b/.github/workflows/setup-registry-identities.yml
@@ -1,0 +1,173 @@
+name: registry-identities
+
+on:
+  workflow_call:
+    inputs:
+      registry-identities:
+        type: string
+        description: "Keyless registry identity configuration as YAML objects"
+        required: false
+    outputs:
+      aws-ecr-enabled:
+        description: "Whether an AWS ECR registry identity was configured"
+        value: ${{ jobs.setup-registry-identities.outputs.aws-ecr-enabled }}
+      aws-ecr-role-to-assume:
+        description: "AWS IAM role ARN to assume for ECR authentication"
+        value: ${{ jobs.setup-registry-identities.outputs.aws-ecr-role-to-assume }}
+      aws-ecr-region:
+        description: "AWS region to use for ECR authentication"
+        value: ${{ jobs.setup-registry-identities.outputs.aws-ecr-region }}
+      aws-ecr-registry-auth:
+        description: "Registry auth YAML for Docker login"
+        value: ${{ jobs.setup-registry-identities.outputs.aws-ecr-registry-auth }}
+
+env:
+  RUNTIME_MODULE: "@docker/github-builder-runtime@0.92.0"
+  RUNTIME_INSTALL_ARGS: |
+    --loglevel=error
+    --no-save
+    --package-lock=false
+    --ignore-scripts
+    --omit=dev
+    --prefer-offline
+    --fund=false
+    --audit=false
+  NPM_CONFIG_FETCH_RETRIES: "5"
+
+jobs:
+  setup-registry-identities:
+    runs-on: ubuntu-24.04
+    outputs:
+      aws-ecr-enabled: ${{ steps.validate.outputs.aws-ecr-enabled }}
+      aws-ecr-role-to-assume: ${{ steps.validate.outputs.aws-ecr-role-to-assume }}
+      aws-ecr-region: ${{ steps.validate.outputs.aws-ecr-region }}
+      aws-ecr-registry-auth: ${{ steps.validate.outputs.aws-ecr-registry-auth }}
+    steps:
+      -
+        name: Install dependencies
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_RUNTIME-MODULE: ${{ env.RUNTIME_MODULE }}
+          INPUT_RUNTIME-INSTALL-ARGS: ${{ env.RUNTIME_INSTALL_ARGS }}
+          INPUT_REGISTRY-IDENTITIES: ${{ inputs.registry-identities }}
+        with:
+          script: |
+            const registryIdentities = core.getInput('registry-identities', {trimWhitespace: false});
+            if (!registryIdentities.trim()) {
+              core.info('No registry identities configured; skipping npm install');
+              return;
+            }
+
+            const npmArgs = ['install', ...core.getMultilineInput('runtime-install-args'), core.getInput('runtime-module')];
+            const maxAttempts = 3;
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const exitCode = await exec.exec('npm', npmArgs, {ignoreReturnCode: true});
+              if (exitCode === 0) {
+                return;
+              }
+              if (attempt === maxAttempts) {
+                core.setFailed(`npm install failed after ${maxAttempts} attempts`);
+                return;
+              }
+              const retryDelayMs = attempt * 50;
+              core.info(`npm install failed with exit code ${exitCode}; retrying in ${retryDelayMs}ms`);
+              await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+            }
+      -
+        name: Validate registry identities
+        id: validate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_REGISTRY-IDENTITIES: ${{ inputs.registry-identities }}
+        with:
+          script: |
+            const setEmptyOutputs = () => {
+              core.setOutput('aws-ecr-enabled', 'false');
+              core.setOutput('aws-ecr-role-to-assume', '');
+              core.setOutput('aws-ecr-region', '');
+              core.setOutput('aws-ecr-registry-auth', '');
+            };
+
+            const registryIdentities = core.getInput('registry-identities', {trimWhitespace: false});
+            if (!registryIdentities.trim()) {
+              core.info('No registry identities configured; skipping validation');
+              setEmptyOutputs();
+              return;
+            }
+
+            let yaml;
+            try {
+              yaml = require('js-yaml');
+            } catch {
+              yaml = require('@docker/github-builder-runtime/node_modules/js-yaml');
+            }
+
+            const fail = message => {
+              throw new Error(`Invalid registry-identities input: ${message}`);
+            };
+            const ensureObject = (value, path) => {
+              if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                fail(`${path} must be an object`);
+              }
+            };
+            const requireString = (entry, key, path) => {
+              const value = entry[key];
+              if (typeof value !== 'string' || !value.trim()) {
+                fail(`${path}.${key} must be a non-empty string`);
+              }
+              return value.trim();
+            };
+            let parsed;
+            try {
+              parsed = yaml.load(registryIdentities);
+            } catch (error) {
+              fail(error.message);
+            }
+            if (parsed === null || parsed === undefined) {
+              setEmptyOutputs();
+              return;
+            }
+
+            const entries = Array.isArray(parsed) ? parsed : [parsed];
+            if (entries.length === 0) {
+              setEmptyOutputs();
+              return;
+            }
+
+            let awsEcr;
+            entries.forEach((entry, index) => {
+              const path = `registry-identities[${index}]`;
+              ensureObject(entry, path);
+              const type = requireString(entry, 'type', path);
+              switch (type) {
+                case 'aws-ecr': {
+                  const allowedKeys = new Set(['type', 'aws-region', 'role-to-assume', 'registry']);
+                  for (const key of Object.keys(entry)) {
+                    if (!allowedKeys.has(key)) {
+                      fail(`${path}.${key} is not supported for aws-ecr`);
+                    }
+                  }
+                  if (awsEcr) {
+                    fail('only one aws-ecr registry identity is supported');
+                  }
+                  const awsRegion = requireString(entry, 'aws-region', path);
+                  const roleToAssume = requireString(entry, 'role-to-assume', path);
+                  const registry = requireString(entry, 'registry', path);
+                  awsEcr = {
+                    awsRegion,
+                    roleToAssume,
+                    registryAuth: yaml.dump([{
+                      registry
+                    }], {lineWidth: -1})
+                  };
+                  break;
+                }
+                default:
+                  fail(`${path}.type has unsupported provider ${type}`);
+              }
+            });
+
+            core.setOutput('aws-ecr-enabled', awsEcr ? 'true' : 'false');
+            core.setOutput('aws-ecr-role-to-assume', awsEcr?.roleToAssume || '');
+            core.setOutput('aws-ecr-region', awsEcr?.awsRegion || '');
+            core.setOutput('aws-ecr-registry-auth', awsEcr?.registryAuth || '');

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,8 +6,5 @@ rules:
     ignore:
       - bake.yml
       - build.yml
+      - setup-registry-identities.yml
       - verify.yml
-
-  # FIXME: remove this rule when zizmor 1.24.0 is released, fixing the right persona attached to this rule: https://github.com/zizmorcore/zizmor/pull/1783
-  secrets-outside-env:
-    disable: true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ___
   * [Outputs](#outputs-1)
 * [Notes](#notes)
   * [Signed GitHub Actions cache](#signed-github-actions-cache)
+  * [Registry identities](#registry-identities)
   * [Runner mapping](#runner-mapping)
   * [Metadata templates](#metadata-templates)
 
@@ -235,6 +236,7 @@ jobs:
 | `output`                  | String   |                                       | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/)). Unlike the `build-push-action`, it only accepts `image` or `local`. The reusable workflow takes care of setting the `outputs` attribute |
 | `platforms`               | List/CSV |                                       | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) to build                                                                                                                                                                                               |
 | `push`                    | Bool     | `false`                               | [Push](https://docs.docker.com/engine/reference/commandline/buildx_build/#push) image to the registry (for `image` output)                                                                                                                                                                                     |
+| `registry-identities`     | YAML     |                                       | Keyless registry identity configuration. See [Registry identities](#registry-identities).                                                                                                                                                                                                                      |
 | `sbom`                    | Bool     | `false`                               | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                                    |
 | `shm-size`                | String   |                                       | Size of [`/dev/shm`](https://docs.docker.com/engine/reference/commandline/buildx_build/#shm-size) (e.g., `2g`)                                                                                                                                                                                                 |
 | `sign`                    | String   | `auto`                                | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact           |
@@ -344,6 +346,7 @@ jobs:
 | `files`                   | List   | `{context}/docker-bake.hcl`           | List of bake definition files                                                                                                                                                                                                                                                                        |
 | `output`                  | String |                                       | Build output destination (one of [`image`](https://docs.docker.com/build/exporters/image-registry/) or [`local`](https://docs.docker.com/build/exporters/local-tar/)).                                                                                                                               |
 | `push`                    | Bool   | `false`                               | Push image to the registry (for `image` output)                                                                                                                                                                                                                                                      |
+| `registry-identities`     | YAML   |                                       | Keyless registry identity configuration. See [Registry identities](#registry-identities).                                                                                                                                                                                                            |
 | `sbom`                    | Bool   | `false`                               | Generate [SBOM](https://docs.docker.com/build/attestations/sbom/) attestation for the build                                                                                                                                                                                                          |
 | `set`                     | List   |                                       | List of [target values to override](https://docs.docker.com/engine/reference/commandline/buildx_bake/#set) (e.g., `targetpattern.key=value`)                                                                                                                                                         |
 | `sign`                    | String | `auto`                                | Sign attestation manifest for `image` output or artifacts for `local` output, can be one of `auto`, `true` or `false`. The `auto` mode will enable signing if `push` is enabled for pushing the `image` or if `artifact-upload` is enabled for uploading the `local` build output as GitHub Artifact |
@@ -394,6 +397,45 @@ reusable workflows, the Docker-owned workflow is the trusted build boundary.
 Without verification, a poisoned BuildKit cache could influence a later trusted
 build, which is the SLSA isolation concern described in
 [docker/github-builder#56](https://github.com/docker/github-builder/issues/56).
+
+### Registry identities
+
+The `registry-identities` input configures keyless registry authentication from
+non-secret identity metadata. Do not put passwords, tokens, client secrets,
+private keys, raw cloud credential JSON, or other secret values in this input.
+The workflow validates the YAML before any build work starts.
+
+`registry-identities` can be combined with the existing `registry-auths`
+secret. Provider-specific authentication steps are pinned in these reusable
+workflows; callers can only select supported provider types and pass identity
+configuration.
+
+Amazon ECR private registry authentication is configured with `type: aws-ecr`.
+Callers must grant `id-token: write` so the AWS credential step can assume the
+role through GitHub OIDC:
+
+```yaml
+jobs:
+  build:
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestations, cache entries with GitHub OIDC and log in to AWS ECR
+    with:
+      output: image
+      push: ${{ github.event_name != 'pull_request' }}
+      meta-images: |
+        123456789100.dkr.ecr.us-east-1.amazonaws.com/sandbox/test-github-builder
+      registry-identities: |
+        - type: aws-ecr
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::123456789100:role/my-github-actions-role
+          registry: 123456789100.dkr.ecr.us-east-1.amazonaws.com
+```
+
+The `registry` value is required for AWS ECR. Use the registry server that
+`docker/login-action` should log in to, such as `public.ecr.aws` for public ECR
+or `123456789100.dkr.ecr.us-east-1.amazonaws.com` for private ECR.
 
 ### Runner mapping
 


### PR DESCRIPTION
relates to https://github.com/docker/github-builder/issues/146

This adds a `registry-identities` input to the reusable `build.yml` and `bake.yml` workflows so callers can authenticate to registries through keyless identity metadata instead of passing static registry credentials. The first supported provider is AWS ECR through GitHub OIDC and `aws-actions/configure-aws-credentials`, followed by `docker/login-action` using ambient AWS credentials.

This introduces a shared `setup-registry-identities.yml` reusable workflow that parses the YAML input before build work starts. The build and bake workflows call that parser, configure AWS credentials when an `aws-ecr` identity is present, and then run a separate `docker/login-action` step with generated ECR `registry-auth` entries. Existing `registry-auths` secrets continue to work through a separate login step, so secret-based auth and identity-based auth are not merged into the same YAML payload.

The `aws-ecr` identity currently accepts one registry identity with `aws-region`, `role-to-assume`, and `registry`. Callers pass the exact ECR registry server that should be used for Docker login, such as `175142243308.dkr.ecr.us-east-2.amazonaws.com` for private ECR or `public.ecr.aws` for public ECR.

The goal is to let callers move AWS ECR authentication away from long-lived static credentials while keeping the provider-specific auth steps pinned and controlled inside GitHub Builder.