### PR TITLE
build/bake: fail fast on dependency signature verification errors

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -262,17 +262,17 @@ jobs:
             const sigstore = new Sigstore();
             
             for (const image of core.getMultilineInput('images')) {
-              await core.group(`Verifying ${image}`, async () => {
-                try {
+              try {
+                await core.group(`Verifying ${image}`, async () => {
                   await sigstore.verifyImageAttestations(image, {
                     certificateIdentityRegexp: `^https://github.com/docker/github-builder(-experimental)?/.github/workflows/bake.yml.*$`,
                     platform: OCI.defaultPlatform()
                   });
-                } catch (error) {
-                  core.setFailed(error);
-                  return;
-                }
-              });
+                });
+              } catch (error) {
+                core.setFailed(`Failed to verify ${image}: ${error.message || error}`);
+                return;
+              }
             }
       -
         name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,17 +266,17 @@ jobs:
             const sigstore = new Sigstore();
             
             for (const image of core.getMultilineInput('images')) {
-              await core.group(`Verifying ${image}`, async () => {
-                try {
+              try {
+                await core.group(`Verifying ${image}`, async () => {
                   await sigstore.verifyImageAttestations(image, {
                     certificateIdentityRegexp: `^https://github.com/docker/github-builder(-experimental)?/.github/workflows/bake.yml.*$`,
                     platform: OCI.defaultPlatform()
                   });
-                } catch (error) {
-                  core.setFailed(error);
-                  return;
-                }
-              });
+                });
+              } catch (error) {
+                core.setFailed(`Failed to verify ${image}: ${error.message || error}`);
+                return;
+              }
             }
       -
         name: Set outputs


### PR DESCRIPTION
relates to https://github.com/crazy-max/xgo/actions/runs/29336003773/job/87096835413?pr=198#step:4:1

<img width="655" height="213" alt="image" src="https://github.com/user-attachments/assets/f87afafc-2f94-450d-8bd9-cc667eda9e95" />

<img width="1897" height="396" alt="image" src="https://github.com/user-attachments/assets/58d8e1ac-d534-4807-9310-cf599915aa8b" />

Dependency signature verification now reports failures after the log group closes so the error is visible in the workflow step summary.

The verification loop now rethrows the first failure instead of only marking the action as failed, which stops later dependency checks from running after an invalid signature result.

Also looking at the error:

```
Error: Error: Cosign verify command failed with: error during command execution: trusted root is required when using new bundle format
```

It seems cosign is not able to download tuf (probably flaky network). This could be solved with https://github.com/docker/actions-toolkit/pull/1133.