### PR TITLE
build: fix workflow metadata inputs

### DIFF
--- a/.github/workflows/.test-bake.yml
+++ b/.github/workflows/.test-bake.yml
@@ -578,9 +578,12 @@ jobs:
         *.args.VERSION={{meta.version}}
       target: hello-cross
       set-meta-annotations: true
+      set-meta-labels: true
       meta-images: ghcr.io/docker/github-builder-test
       meta-tags: |
         type=raw,value=bake-index-annotations-${{ github.run_id }}
+      meta-labels: |
+        io.github.docker.github-builder.test-label=bake-${{ github.run_id }}
       meta-annotations: |
         io.github.docker.github-builder.test-index-annotation=bake-${{ github.run_id }}
     secrets:

--- a/.github/workflows/.test-build.yml
+++ b/.github/workflows/.test-build.yml
@@ -344,7 +344,7 @@ jobs:
         name: Builder outputs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          INPUT_BUILDER-OUTPUTS: ${{ toJSON(needs.local.outputs) }}
+          INPUT_BUILDER-OUTPUTS: ${{ toJSON(needs.build-local.outputs) }}
         with:
           script: |
             const builderOutputs = JSON.parse(core.getInput('builder-outputs'));
@@ -590,6 +590,8 @@ jobs:
     with:
       annotations: |
         io.github.docker.github-builder.test-index-annotation=build-${{ github.run_id }}
+      labels: |
+        io.github.docker.github-builder.test-label=build-${{ github.run_id }}
       build-args: |
         VERSION={{meta.version}}
       file: test/hello.Dockerfile
@@ -598,6 +600,7 @@ jobs:
       push: ${{ github.event_name != 'pull_request' }}
       sbom: true
       set-meta-annotations: true
+      set-meta-labels: true
       meta-images: ghcr.io/docker/github-builder-test
       meta-tags: |
         type=raw,value=build-index-annotations-${{ github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -558,8 +558,6 @@ jobs:
           images: ${{ needs.prepare.outputs.metaImages }}
           tags: ${{ inputs.meta-tags }}
           flavor: ${{ inputs.meta-flavor }}
-          labels: ${{ inputs.meta-labels }}
-          annotations: ${{ inputs.meta-annotations }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
@@ -1030,8 +1028,6 @@ jobs:
           images: ${{ needs.prepare.outputs.metaImages }}
           tags: ${{ inputs.meta-tags }}
           flavor: ${{ inputs.meta-flavor }}
-          labels: ${{ inputs.meta-labels }}
-          annotations: ${{ inputs.meta-annotations }}
       -
         name: Login to registry
         if: ${{ inputs.push && inputs.output == 'image' }}


### PR DESCRIPTION
fixes #255 
closes #256

The build workflow now relies on its existing labels and annotations inputs instead of forwarding undefined metadata-action inputs.