### PR TITLE
bake: fix missing privateRepo output

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -208,6 +208,7 @@ jobs:
       includes: ${{ steps.set.outputs.includes }}
       metaImages: ${{ steps.set.outputs.metaImages }}
       sign: ${{ steps.set.outputs.sign }}
+      privateRepo: ${{ steps.set.outputs.privateRepo }}
       ghaCacheSign: ${{ steps.set.outputs.ghaCacheSign }}
     steps:
       -


### PR DESCRIPTION
The bake workflow uses `needs.prepare.outputs.privateRepo` when configuring cache verification. The prepare job already calculates the value, but it didn't expose it as a job output, which makes the reference undefined.