### PR TITLE
bake: allow the default target input to apply

### DIFF
--- a/.github/workflows/bake.yml
+++ b/.github/workflows/bake.yml
@@ -94,7 +94,7 @@ on:
       target:
         type: string
         description: "Bake target to build"
-        required: true
+        required: false
         default: default
       vars:
         type: string


### PR DESCRIPTION
The bake workflow declared `target` as required while also setting default: `default`. GitHub Actions never uses a default for a required `workflow_call` input, so make target optional to match the documented default behavior.